### PR TITLE
docs(ghpm): add operating rule to always create feature branch

### DIFF
--- a/commands/ghpm/ghpm:execute.md
+++ b/commands/ghpm/ghpm:execute.md
@@ -56,6 +56,7 @@ Both workflows produce identical outputs: conventional commits, Task Report, and
 
 <operating_rules>
 
+- Always create a feature branch before making changes. Never commit directly to main/master.
 - No local markdown artifacts. Do not write local status files; only code changes + GitHub issue/PR updates.
 - Do NOT use the TodoWrite tool to track tasks during this session.
 - Do not silently expand scope. If needed, create a new follow-up Task issue and link it.

--- a/commands/ghpm/ghpm:tdd-task.md
+++ b/commands/ghpm/ghpm:tdd-task.md
@@ -52,6 +52,7 @@ Implement a GitHub Task issue using disciplined TDD (Red -> Green -> Refactor), 
 
 <operating_rules>
 
+- Always create a feature branch before making changes. Never commit directly to main/master.
 - No local markdown artifacts. Do not write local status files; only code changes + GitHub issue/PR updates.
 - Do NOT use the TodoWrite tool to track tasks during this session.
 - Do not silently expand scope. If you must, create a new follow-up Task issue and link it.


### PR DESCRIPTION
## Summary

- Adds explicit guidance to `ghpm:execute` and `ghpm:tdd-task` commands to always create a feature branch before making changes
- Prevents agents from committing directly to main/master

This rule was missing from the operating rules, which led to a previous commit being made directly to main instead of on a feature branch.

## Test plan

- [ ] Verify the rule appears in both command files' `<operating_rules>` section
- [ ] Run a GHPM command and confirm the agent creates a branch first

🤖 Generated with [Claude Code](https://claude.com/claude-code)