### PR TITLE
feat(ghpm): implement ghpm:qa-create command (#6)

### DIFF
--- a/commands/ghpm/ghpm:qa-create.md
+++ b/commands/ghpm/ghpm:qa-create.md
@@ -157,3 +157,42 @@ COMMENT
 echo "Posted QA link comment on PRD #$PRD"
 ```
 
+## Operating rules
+
+- Do not ask clarifying questions. If the PRD has ambiguity, derive a reasonable overview from the PRD objective.
+- Do not create local markdown files. All output goes into GitHub issues/comments.
+- Execute all `gh` commands directly via bash tool.
+- If sub-issue linking fails, continue with the remaining steps (best-effort).
+
+## Error handling
+
+| Error | Action |
+|-------|--------|
+| `gh auth` not authenticated | Print error: "GitHub CLI not authenticated. Run `gh auth login` first." |
+| PRD number invalid (not a positive integer) | Print error: "Invalid PRD number. Use format: prd=#123" |
+| PRD not found or inaccessible | Print error: "Could not fetch PRD #N. Check if it exists and you have access." |
+| QA Issue creation fails | Print error and stop. Do not proceed with linking or comments. |
+| Sub-issue linking fails | Print warning, continue with remaining steps. |
+| Project add fails | Print warning, continue with remaining steps. |
+
+## Output requirements
+
+Execute all `gh` commands yourself (via bash tool). Print a summary at completion:
+
+- PRD #, title, URL
+- QA Issue #, title, URL
+- Sub-issue linking: success/warning
+- Project association: success/warning/skipped
+- PRD comment: posted
+
+## Success criteria
+
+Command completes successfully when:
+
+- [ ] QA Issue created with correct title format and QA label
+- [ ] QA Issue body contains all required sections
+- [ ] QA Issue linked as sub-issue of PRD (or warning printed)
+- [ ] PRD has comment linking to QA Issue
+- [ ] Summary printed with all relevant URLs
+
+Proceed now.


### PR DESCRIPTION
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18

## Summary

Implements the `/ghpm:qa-create` command that creates a QA Issue as a sub-issue of a PRD, establishing the foundation for structured acceptance testing within the GHPM workflow.

### Tasks Completed

- **#11**: Create ghpm:qa-create.md command file with YAML frontmatter
- **#12**: Define QA Issue body template structure
- **#13**: Implement PRD resolution logic for qa-create
- **#14**: Implement QA Issue creation with QA label
- **#15**: Implement sub-issue linking for QA to PRD
- **#16**: Add GitHub Project association for QA Issues
- **#17**: Add PRD comment linking to created QA Issue
- **#18**: Add operating rules and error handling to qa-create

### Features

- Creates QA Issue with standard template (Overview, Parent PRD, QA Steps, Status)
- Supports explicit `prd=#N` argument or auto-resolves to most recent open PRD
- Creates/ensures `QA` label exists
- Links QA Issue as sub-issue of PRD via GitHub API
- Optionally adds to GitHub Project if `GHPM_PROJECT` is set
- Comments on PRD with link to QA Issue

## Verification

- [x] Command file follows existing GHPM patterns
- [x] YAML frontmatter is valid
- [x] All required sections are present
- [x] Error handling covers expected failure cases

## Commits

- `feat(ghpm): create ghpm:qa-create.md command file with YAML frontmatter (#11)`
- `feat(ghpm): define QA Issue body template structure (#12)`
- `feat(ghpm): implement PRD resolution logic for qa-create (#13)`
- `feat(ghpm): implement QA Issue creation with QA label (#14)`
- `feat(ghpm): implement sub-issue linking for QA to PRD (#15)`
- `feat(ghpm): add GitHub Project association for QA Issues (#16)`
- `feat(ghpm): add PRD comment linking to created QA Issue (#17)`
- `feat(ghpm): add operating rules and error handling to qa-create (#18)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)