### PR TITLE
fix(ghpm): add task count guidance to prevent over-decomposition

### DIFF
--- a/commands/ghpm/ghpm:create-tasks.md
+++ b/commands/ghpm/ghpm:create-tasks.md
@@ -59,9 +59,44 @@ You are GHPM (GitHub Project Manager). Convert an Epic into a set of atomic Task
 - Do not create local markdown files. All output goes into GitHub issues/comments.
 - Tasks must be atomic and independently executable by a human or agent.
 - Each Task must include all context needed for its scope (plus links to Epic/PRD).
-- Generate 1-25 tasks per Epic (best effort) that fully cover the Epic scope.
 - Each Task MUST include a **Commit Type** (`feat`, `fix`, `refactor`, etc.) and **Scope** for conventional commits.
+- **Task count must be proportional to Epic scope** - see guidance below.
 </operating_rules>
+
+<task_count_guidance>
+
+## Determining Appropriate Task Count
+
+**Match task count to Epic complexity, not a fixed range.** Over-decomposition creates overhead without value.
+
+### Heuristics
+
+| Epic Scope | Task Count | Example |
+|------------|------------|---------|
+| Single file, simple change | 1 task | Update README, fix typo, change config |
+| Single file, multiple changes | 1-2 tasks | Refactor a module, update docs with verification |
+| Multiple related files | 2-4 tasks | Add feature touching model + controller + view |
+| Cross-cutting feature | 4-8 tasks | New API endpoint with auth, tests, docs |
+| Large architectural change | 8-15 tasks | Database migration, new service layer |
+
+### Signs of Over-Decomposition
+
+- Tasks that would result in the same commit
+- Tasks that can't be meaningfully verified independently
+- "Verify X" as a separate task from "Update X"
+- Multiple tasks touching the same file for related changes
+
+### Signs of Under-Decomposition
+
+- Task requires multiple unrelated commits
+- Task touches many files across different concerns
+- Task has acceptance criteria spanning multiple features
+
+### Rule of Thumb
+
+**If an Epic affects 1-2 files with a clear scope, 1-2 tasks is usually sufficient.**
+
+</task_count_guidance>
 
 <input_validation>
 
@@ -193,7 +228,7 @@ gh issue view "$EPIC" --json title,body,url,labels -q '.'
 
 ## Step 3: Generate Task Issues
 
-For each Epic, generate 5-25 atomic tasks that fully cover the Epic scope.
+For each Epic, generate the appropriate number of atomic tasks based on the task count guidance above.
 
 Create each task:
 
@@ -293,7 +328,7 @@ gh issue comment "$PRD" --body "Tasks created for Epic #$EPIC - see checklist on
 Command completes successfully when:
 
 1. All target Epics have been processed
-2. Each Epic has 5-25 Task issues created
+2. Each Epic has an appropriate number of Task issues (per task count guidance)
 3. Each Task issue contains complete context (Epic/PRD links, acceptance criteria)
 4. Each Task is linked as a sub-issue of its Epic
 5. PRD is notified (if applicable)


### PR DESCRIPTION
## Summary
- Added `<task_count_guidance>` section with heuristics for appropriate task counts
- Replaced hardcoded "5-25 tasks" references with scope-proportional guidance
- Added anti-patterns for over-decomposition and under-decomposition

## Problem
The `ghpm:create-tasks` command was generating too many tasks for simple Epics. For example, a single-file README update was split into 5 separate tasks (replace link, verify table, verify install, verify diagram, final review) when 1 task would suffice.

## Solution
Added explicit guidance:

| Epic Scope | Task Count | Example |
|------------|------------|---------|
| Single file, simple change | 1 task | Update README, fix typo |
| Single file, multiple changes | 1-2 tasks | Refactor a module |
| Multiple related files | 2-4 tasks | Feature touching MVC |
| Cross-cutting feature | 4-8 tasks | New API with auth/tests/docs |
| Large architectural change | 8-15 tasks | DB migration, new service |

## Test plan
- [x] Verified command file parses correctly
- [ ] Run `/ghpm:create-tasks` on a narrow-scope Epic to confirm reduced task count

🤖 Generated with [Claude Code](https://claude.com/claude-code)