### PR TITLE
docs(ghpm): update README with release-please reference (#69)

### DIFF
--- a/commands/ghpm/README.md
+++ b/commands/ghpm/README.md
@@ -133,4 +133,4 @@ All commits and PR titles follow [Conventional Commits](https://www.conventional
 | `docs` | Documentation |
 | `chore` | Build/CI/tooling |
 
-This enables automated changelog generation via `/ghpm:changelog` or tools like [standard-version](https://github.com/conventional-changelog/standard-version).
+This enables automated changelog generation via `/ghpm:changelog` or tools like [release-please](https://github.com/googleapis/release-please).


### PR DESCRIPTION
Closes #69

## Summary

- Replaced deprecated `standard-version` reference with `release-please` link in GHPM README
- Verified command table, install script file list, and workflow diagram are accurate

## Verification

- **Command table:** 9 commands listed match 9 actual command files ✓
- **Install script:** Copies exactly the files listed in README ✓
- **Workflow diagram:** Accurately reflects current command structure ✓
- **release-please link:** Points to https://github.com/googleapis/release-please ✓

## Commits

- `docs(ghpm): replace standard-version with release-please reference (#69)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)