### PR TITLE
refactor(ghpm): streamline Epic and Task issue templates (#79)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,16 +1,21 @@
 {
   "permissions": {
     "allow": [
+      "Bash(do gh issue close:*)",
+      "Bash(done)",
+      "Bash(for i in:*)",
       "Bash(gh api --help:*)",
       "Bash(gh api:*)",
       "Bash(gh help:*)",
       "Bash(gh issue --help:*)",
+      "Bash(gh issue close:*)",
       "Bash(gh issue comment:*)",
       "Bash(gh issue create-comment:*)",
       "Bash(gh issue create:*)",
       "Bash(gh issue edit:*)",
       "Bash(gh issue view:*)",
       "Bash(gh label create:*)",
+      "Bash(gh pr create:*)",
       "Bash(gh project item-add:*)",
       "Bash(git add:*)",
       "Bash(git checkout:*)",

--- a/commands/ghpm/ghpm:create-epics.md
+++ b/commands/ghpm/ghpm:create-epics.md
@@ -74,40 +74,41 @@ export GHPM_PROJECT="MyOrg/Q1 Roadmap"
 
 ## Required Epic Structure (Issue Body)
 
-Use this exact outline:
+Use this streamlined template. Omit optional sections if empty.
 
 ```markdown
 # Epic: <Name>
 
+**PRD:** #<PRD_NUMBER>
+
 ## Objective
-<What this Epic accomplishes>
+<1-3 sentences: what this Epic accomplishes and delivers>
 
-## Scope (In)
-<Specific deliverables included>
+## Scope
+<Bulleted list of specific deliverables - merge any "Key Requirements" here>
 
-## Out of Scope
-<What is NOT part of this Epic>
-
-## Key Requirements (from PRD)
-<Requirements from PRD that this Epic addresses>
-
-## Acceptance Criteria (Epic-level)
+## Acceptance Criteria
 - [ ] Criterion 1
 - [ ] Criterion 2
 - [ ] ...
 
 ## Dependencies
-<Other Epics, external systems, or prerequisites>
-
-## Risks / Edge Cases
-<Known risks and edge cases to address>
-
-## Notes / Open Questions
-<Any assumptions or questions>
-
-## Links
-- PRD: #<PRD_NUMBER>
+<Only include if external dependencies exist; omit section entirely if none>
 ```
+
+### Template Guidance
+
+- **PRD link**: Single line at top, not a separate "Links" section
+- **Objective**: Concise statement of what this Epic delivers (not duplicating PRD content)
+- **Scope**: Specific deliverables; merge "Key Requirements" here rather than separate section
+- **Acceptance Criteria**: Checkboxes for Epic-level verification
+- **Dependencies**: Only include if there are actual dependencies; omit if none
+
+**Omit these sections** (redundant with PRD or rarely populated):
+- Out of Scope (inherit from PRD)
+- Risks / Edge Cases (inherit from PRD)
+- Notes / Open Questions (use issue comments instead)
+- Key Requirements (merge into Scope)
 
 </epic_issue_format>
 
@@ -310,11 +311,12 @@ gh issue comment "$PRD" --body "$COMMENT_BODY"
 Command completes successfully when:
 
 1. All Epic issues are created with "Epic" label
-2. Each Epic body contains all required sections from Epic structure
-3. Each Epic references the PRD by number in Links section
+2. Each Epic body contains required sections: PRD link, Objective, Scope, Acceptance Criteria
+3. Each Epic references the PRD at the top of the body
 4. All Epics are linked as sub-issues of the PRD (or warnings issued)
 5. Summary comment is posted to PRD
 6. If `GHPM_PROJECT` set, Epics are added to project (or warnings issued)
+7. Optional sections (Dependencies) only included when populated with meaningful content
 
 **Verification:**
 

--- a/commands/ghpm/ghpm:create-tasks.md
+++ b/commands/ghpm/ghpm:create-tasks.md
@@ -121,31 +121,39 @@ gh issue view "$EPIC" > /dev/null 2>&1 || { echo "ERROR: Cannot access issue #$E
 
 ## Task Issue Body Template
 
+Use this streamlined template. Tasks link to Epic only (PRD reachable via Epic).
+
 ```markdown
 # Task: <Name>
 
-## Context
-- Epic: #<EPIC_NUMBER>
-- PRD: #<PRD_NUMBER> (if known)
-- Commit Type: `<type>` (feat|fix|refactor|test|docs|chore)
-- Scope: `<scope>` (module/component affected)
+**Epic:** #<EPIC_NUMBER> | **Type:** `<type>` | **Scope:** `<scope>`
 
 ## Objective
+<1-2 sentences: what to implement>
 
-## Scope (In)
-
-## Out of Scope
-
-## Acceptance Criteria (task-level, testable)
-
-## Implementation Notes (non-binding)
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] ...
 
 ## Test Plan
-
-## Risks / Edge Cases
-
-## Notes / Open Questions
+<How to verify completion - manual steps, test commands, or verification approach>
 ```
+
+### Template Guidance
+
+- **Context line**: Single line with Epic link, commit type, and scope (no PRD link - navigate via Epic)
+- **Objective**: Concise statement merging previous "Objective" and "Scope (In)" sections
+- **Acceptance Criteria**: Task-level, testable criteria
+- **Test Plan**: How to verify the task is complete
+
+**Omit these sections** (redundant or rarely populated):
+- PRD link (reachable via Epic)
+- Scope (In) (merge into Objective)
+- Out of Scope (inherit from Epic)
+- Implementation Notes (use comments if needed)
+- Risks / Edge Cases (inherit from Epic/PRD)
+- Notes / Open Questions (use issue comments instead)
 
 ### Commit Type Guidelines
 
@@ -329,9 +337,10 @@ Command completes successfully when:
 
 1. All target Epics have been processed
 2. Each Epic has an appropriate number of Task issues (per task count guidance)
-3. Each Task issue contains complete context (Epic/PRD links, acceptance criteria)
+3. Each Task issue contains required sections: Context line (Epic, Type, Scope), Objective, Acceptance Criteria, Test Plan
 4. Each Task is linked as a sub-issue of its Epic
 5. PRD is notified (if applicable)
+6. Optional sections omitted when not populated with meaningful content
 
 **Verification:**
 


### PR DESCRIPTION
Closes #79

## Summary

- Streamlined Epic template: reduced from 9 sections to 4 (PRD link, Objective, Scope, Acceptance Criteria, Dependencies optional)
- Streamlined Task template: reduced from 10 sections to 3 + context line (Epic, Type, Scope)
- Added template guidance for conditional section inclusion
- Removed redundant sections: Out of Scope, Risks/Edge Cases, Notes/Open Questions, Key Requirements
- Implemented single parent link principle (Task → Epic only, Epic → PRD only)

## Verification

- Manual review of template changes
- Template structure aligns with PRD #76 requirements
- Estimated ~50% reduction in issue body length

## Commits

- `82a3c7c` refactor(ghpm): streamline Epic and Task issue templates (#79)

🤖 Generated with [Claude Code](https://claude.com/claude-code)