### PR TITLE
feat(ghpm): add interactive project selection to create-prd

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,6 +17,7 @@
       "Bash(gh label create:*)",
       "Bash(gh pr create:*)",
       "Bash(gh project item-add:*)",
+      "Bash(gh project list:*)",
       "Bash(git add:*)",
       "Bash(git checkout:*)",
       "Bash(git commit:*)",


### PR DESCRIPTION
## Summary

- Adds interactive project selection when `GHPM_PROJECT` is not pre-set
- Queries available GitHub projects for the repository owner using `gh project list`
- Prompts user via `AskUserQuestion` to select a project (up to 4 options + "None")
- Allows skipping project association by selecting "None"
- Includes permission for `gh project list` in settings

## Test plan

- [ ] Run `/ghpm:create-prd` without `GHPM_PROJECT` set - should prompt for project selection
- [ ] Run `/ghpm:create-prd` with `GHPM_PROJECT` pre-set - should skip prompt
- [ ] Test with owner that has no projects - should show informative message and skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)