### PR TITLE
fix(ghpm): add create-project to install script

### DIFF
--- a/commands/ghpm/scripts/install-ghpm-claude-commands.sh
+++ b/commands/ghpm/scripts/install-ghpm-claude-commands.sh
@@ -8,6 +8,7 @@ SOURCE_DIR="$(dirname "$SCRIPT_DIR")"
 ROOT="${1:-.}"
 mkdir -p "$ROOT/.claude/commands"
 
+cp -f "$SOURCE_DIR/ghpm:create-project.md"  "$ROOT/.claude/commands/ghpm:create-project.md"
 cp -f "$SOURCE_DIR/ghpm:create-prd.md"      "$ROOT/.claude/commands/ghpm:create-prd.md"
 cp -f "$SOURCE_DIR/ghpm:create-epics.md"    "$ROOT/.claude/commands/ghpm:create-epics.md"
 cp -f "$SOURCE_DIR/ghpm:create-tasks.md"    "$ROOT/.claude/commands/ghpm:create-tasks.md"


### PR DESCRIPTION
## Summary
- Added missing `ghpm:create-project.md` to the install script
- The install script now correctly installs all 10 GHPM commands

## Test plan
- [x] Run install script and verify all commands are copied
- [x] Verify `ghpm:create-project.md` is included in the installed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)