### PR TITLE
docs(ghpm): document execute command routing in README

### DIFF
--- a/commands/ghpm/README.md
+++ b/commands/ghpm/README.md
@@ -106,7 +106,7 @@ GHPM supports two parallel workflows that start from a PRD:
              │                        │                        │
              ▼                        ▼                        ▼
        ┌────────────┐           ┌────────────┐           ┌────────────┐
-       │  Execute   │           │  Execute   │           │ QA Execute │
+       │Execute/TDD │           │Execute/TDD │           │ QA Execute │
        └────────────┘           └────────────┘           └─────┬──────┘
                                                                │
                                                         ┌──────┴──────┐


### PR DESCRIPTION
## Summary
- Updated workflow diagram to show "Execute" instead of "TDD" for implementation step
- Changed step 5 in Implementation Workflow to reference `/ghpm:execute` as the primary command
- Added new "Execute Command Routing" section explaining how tasks are routed to TDD or non-TDD workflows
- Included usage examples for single task and epic execution

## Context
The `/ghpm:execute` command was listed in the commands table but not documented in the workflow sections. This command is the recommended way to implement tasks as it intelligently routes to TDD or non-TDD workflows based on commit type and target files.

## Test plan
- [x] Verify markdown renders correctly
- [x] Confirm routing table accurately reflects the execute command logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)