### PR TITLE
fix: update marketplace plugin source paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "ruby-rails",
-      "source": "./ruby-rails",
+      "source": "./plugins/ruby-rails",
       "description": "Ruby on Rails development toolkit with skills for Rails, Ruby, RSpec, RuboCop, SimpleCov, Brakeman, and code review with Sandi Metz principles",
       "version": "0.1.0",
       "author": {
@@ -20,7 +20,7 @@
     },
     {
       "name": "ghpm",
-      "source": "./ghpm",
+      "source": "./plugins/ghpm",
       "description": "GitHub Project Management workflow for product development: PRD creation, epic/task breakdown, TDD execution, and QA planning",
       "version": "0.1.0",
       "author": {
@@ -29,7 +29,7 @@
     },
     {
       "name": "js-ts",
-      "source": "./js-ts",
+      "source": "./plugins/js-ts",
       "description": "JavaScript and TypeScript development toolkit with ESLint, Vitest, and unit testing best practices",
       "version": "0.1.0",
       "author": {
@@ -38,7 +38,7 @@
     },
     {
       "name": "devops",
-      "source": "./devops",
+      "source": "./plugins/devops",
       "description": "DevOps and infrastructure toolkit with GitHub Actions, Kamal deployment, and Tailscale VPN configuration",
       "version": "0.1.0",
       "author": {
@@ -47,7 +47,7 @@
     },
     {
       "name": "general",
-      "source": "./general",
+      "source": "./plugins/general",
       "description": "General development utilities including Mermaid diagram creation for software documentation",
       "version": "0.1.0",
       "author": {


### PR DESCRIPTION
## Summary

- Fixed "Plugin directory not found" errors when installing plugins from the marketplace
- Updated all plugin `source` paths in marketplace.json to include the `plugins/` directory prefix

**Root cause:** The source paths were `./ruby-rails`, `./ghpm`, etc., but Claude Code resolves these from the repository root rather than combining them with the `pluginRoot` setting.

**Fix:** Changed paths to `./plugins/ruby-rails`, `./plugins/ghpm`, etc.

## Test plan

- [ ] Run `/plugin marketplace add el-feo/ai-context` 
- [ ] Run `/plugin install ruby-rails@jebs-dev-tools` - should succeed without "Plugin directory not found" error
- [ ] Verify other plugins install correctly: ghpm, js-ts, devops, general

🤖 Generated with [Claude Code](https://claude.com/claude-code)