### PR TITLE
fix: add .claude-plugin suffix to marketplace plugin source paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "ruby-rails",
-      "source": "./plugins/ruby-rails",
+      "source": "./plugins/ruby-rails/.claude-plugin",
       "description": "Ruby on Rails development toolkit with skills for Rails, Ruby, RSpec, RuboCop, SimpleCov, Brakeman, and code review with Sandi Metz principles",
       "version": "0.1.0",
       "author": {
@@ -20,7 +20,7 @@
     },
     {
       "name": "ghpm",
-      "source": "./plugins/ghpm",
+      "source": "./plugins/ghpm/.claude-plugin",
       "description": "GitHub Project Management workflow for product development: PRD creation, epic/task breakdown, TDD execution, and QA planning",
       "version": "0.1.0",
       "author": {
@@ -29,7 +29,7 @@
     },
     {
       "name": "js-ts",
-      "source": "./plugins/js-ts",
+      "source": "./plugins/js-ts/.claude-plugin",
       "description": "JavaScript and TypeScript development toolkit with ESLint, Vitest, and unit testing best practices",
       "version": "0.1.0",
       "author": {
@@ -38,7 +38,7 @@
     },
     {
       "name": "devops",
-      "source": "./plugins/devops",
+      "source": "./plugins/devops/.claude-plugin",
       "description": "DevOps and infrastructure toolkit with GitHub Actions, Kamal deployment, and Tailscale VPN configuration",
       "version": "0.1.0",
       "author": {
@@ -47,7 +47,7 @@
     },
     {
       "name": "general",
-      "source": "./plugins/general",
+      "source": "./plugins/general/.claude-plugin",
       "description": "General development utilities including Mermaid diagram creation for software documentation",
       "version": "0.1.0",
       "author": {


### PR DESCRIPTION
## Summary
- Plugin source paths in marketplace.json were missing the `.claude-plugin` subdirectory
- This caused slash commands (and other plugin components) to not be found when installing plugins via the marketplace
- Updated all 5 plugin source paths to include the correct `.claude-plugin` suffix

## Test plan
- [ ] Reinstall the ghpm plugin via marketplace: `/plugin install ghpm@jebs-dev-tools`
- [ ] Verify `/ghpm:create-prd` and other slash commands are now available
- [ ] Test with other plugins (ruby-rails, js-ts, devops, general) to confirm fix works across all plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)