### PR TITLE
fix: add explicit paths to plugin.json for commands, skills, and agents

### DIFF
--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "description": "DevOps and infrastructure toolkit with GitHub Actions, Kamal deployment, and Tailscale VPN configuration",
   "author": {
     "name": "Jeb Coleman"
-  }
+  },
+  "commands": "./commands/",
+  "skills": "./skills/"
 }

--- a/plugins/general/.claude-plugin/plugin.json
+++ b/plugins/general/.claude-plugin/plugin.json
@@ -4,5 +4,6 @@
   "description": "General development utilities including Mermaid diagram creation for software documentation",
   "author": {
     "name": "Jeb Coleman"
-  }
+  },
+  "skills": "./skills/"
 }

--- a/plugins/ghpm/.claude-plugin/plugin.json
+++ b/plugins/ghpm/.claude-plugin/plugin.json
@@ -4,5 +4,6 @@
   "description": "GitHub Project Management workflow for product development: PRD creation, epic/task breakdown, TDD execution, and QA planning",
   "author": {
     "name": "Jeb Coleman"
-  }
+  },
+  "commands": "./commands/"
 }

--- a/plugins/js-ts/.claude-plugin/plugin.json
+++ b/plugins/js-ts/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "description": "JavaScript and TypeScript development toolkit with ESLint, Vitest, and unit testing best practices",
   "author": {
     "name": "Jeb Coleman"
-  }
+  },
+  "commands": "./commands/",
+  "skills": "./skills/"
 }

--- a/plugins/ruby-rails/.claude-plugin/plugin.json
+++ b/plugins/ruby-rails/.claude-plugin/plugin.json
@@ -4,5 +4,8 @@
   "description": "Ruby on Rails development toolkit with skills for Rails, Ruby, RSpec, RuboCop, SimpleCov, Brakeman, and code review with Sandi Metz principles",
   "author": {
     "name": "Jeb Coleman"
-  }
+  },
+  "commands": "./commands/",
+  "skills": "./skills/",
+  "agents": "./agents/"
 }


### PR DESCRIPTION
## Summary
- Add explicit `commands`, `skills`, and `agents` paths to all plugin.json manifests
- Fixes issue where slash commands from installed plugins weren't appearing

## Root Cause
Claude Code looks for `commands/` at the plugin root by default, but our plugins have commands inside `.claude-plugin/commands/`. Without explicit paths in plugin.json, the commands weren't being discovered.

## Changes
| Plugin | Added Fields |
|--------|--------------|
| ghpm | `commands` |
| ruby-rails | `commands`, `skills`, `agents` |
| devops | `commands`, `skills` |
| js-ts | `commands`, `skills` |
| general | `skills` (no commands) |

## Test plan
- [ ] Reinstall a plugin in a target project
- [ ] Verify slash commands appear in `/help`
- [ ] Verify commands execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)