### PR TITLE
fix: use explicit file paths in plugin.json for all plugins

### DIFF
--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,10 +1,16 @@
 {
   "name": "devops",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "DevOps and infrastructure toolkit with GitHub Actions, Kamal deployment, and Tailscale VPN configuration",
   "author": {
     "name": "Jeb Coleman"
   },
-  "commands": "./commands/",
-  "skills": "./skills/"
+  "commands": [
+    "./.claude-plugin/commands/github-actions.md"
+  ],
+  "skills": [
+    "./.claude-plugin/skills/github-actions",
+    "./.claude-plugin/skills/kamal",
+    "./.claude-plugin/skills/tailscale"
+  ]
 }

--- a/plugins/general/.claude-plugin/plugin.json
+++ b/plugins/general/.claude-plugin/plugin.json
@@ -1,9 +1,11 @@
 {
   "name": "general",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "General development utilities including Mermaid diagram creation for software documentation",
   "author": {
     "name": "Jeb Coleman"
   },
-  "skills": "./skills/"
+  "skills": [
+    "./.claude-plugin/skills/mermaid-diagrams"
+  ]
 }

--- a/plugins/ghpm/.claude-plugin/plugin.json
+++ b/plugins/ghpm/.claude-plugin/plugin.json
@@ -1,9 +1,20 @@
 {
   "name": "ghpm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "GitHub Project Management workflow for product development: PRD creation, epic/task breakdown, TDD execution, and QA planning",
   "author": {
     "name": "Jeb Coleman"
   },
-  "commands": "./commands/"
+  "commands": [
+    "./.claude-plugin/commands/changelog.md",
+    "./.claude-plugin/commands/create-epics.md",
+    "./.claude-plugin/commands/create-prd.md",
+    "./.claude-plugin/commands/create-project.md",
+    "./.claude-plugin/commands/create-tasks.md",
+    "./.claude-plugin/commands/execute.md",
+    "./.claude-plugin/commands/qa-create-steps.md",
+    "./.claude-plugin/commands/qa-create.md",
+    "./.claude-plugin/commands/qa-execute.md",
+    "./.claude-plugin/commands/tdd-task.md"
+  ]
 }

--- a/plugins/js-ts/.claude-plugin/plugin.json
+++ b/plugins/js-ts/.claude-plugin/plugin.json
@@ -1,10 +1,16 @@
 {
   "name": "js-ts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "JavaScript and TypeScript development toolkit with ESLint, Vitest, and unit testing best practices",
   "author": {
     "name": "Jeb Coleman"
   },
-  "commands": "./commands/",
-  "skills": "./skills/"
+  "commands": [
+    "./.claude-plugin/commands/vitest.md"
+  ],
+  "skills": [
+    "./.claude-plugin/skills/eslint",
+    "./.claude-plugin/skills/javascript-unit-testing",
+    "./.claude-plugin/skills/vitest"
+  ]
 }

--- a/plugins/ruby-rails/.claude-plugin/plugin.json
+++ b/plugins/ruby-rails/.claude-plugin/plugin.json
@@ -1,11 +1,29 @@
 {
   "name": "ruby-rails",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Ruby on Rails development toolkit with skills for Rails, Ruby, RSpec, RuboCop, SimpleCov, Brakeman, and code review with Sandi Metz principles",
   "author": {
     "name": "Jeb Coleman"
   },
-  "commands": "./commands/",
-  "skills": "./skills/",
-  "agents": "./agents/"
+  "commands": [
+    "./.claude-plugin/commands/rails-generators.md",
+    "./.claude-plugin/commands/red-green-refactor.md",
+    "./.claude-plugin/commands/review-ruby-code.md"
+  ],
+  "skills": [
+    "./.claude-plugin/skills/brakeman",
+    "./.claude-plugin/skills/postgresql-rails-analyzer",
+    "./.claude-plugin/skills/rails",
+    "./.claude-plugin/skills/rails-generators",
+    "./.claude-plugin/skills/review-ruby-code",
+    "./.claude-plugin/skills/rspec",
+    "./.claude-plugin/skills/rubocop",
+    "./.claude-plugin/skills/ruby",
+    "./.claude-plugin/skills/rubycritic",
+    "./.claude-plugin/skills/sandi-metz-reviewer",
+    "./.claude-plugin/skills/simplecov"
+  ],
+  "agents": [
+    "./.claude-plugin/agents/rails-generator-agent.md"
+  ]
 }


### PR DESCRIPTION
## Summary

- Updated all 5 plugin.json files to use explicit paths pointing to `./.claude-plugin/` subdirectories
- Fixed the issue where slash commands weren't showing up when plugins were installed
- The previous paths (`./commands/`, `./skills/`, `./agents/`) incorrectly referenced the plugin root instead of the `.claude-plugin/` directory where these files actually live
- Bumped all plugin versions from 0.1.0 to 0.1.1

## Changes by plugin

| Plugin | Commands | Skills | Agents |
|--------|----------|--------|--------|
| ruby-rails | 3 | 11 | 1 |
| ghpm | 10 | - | - |
| js-ts | 1 | 3 | - |
| devops | 1 | 3 | - |
| general | - | 1 | - |

## Test plan

- [ ] Install a plugin from this repo using `/plugin install`
- [ ] Verify slash commands appear in Claude Code
- [ ] Verify skills are loaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)