### PR TITLE
feat(ruby-rails): add cucumber-gherkin and design-patterns skills

### DIFF
--- a/plugins/ruby-rails/.claude-plugin/plugin.json
+++ b/plugins/ruby-rails/.claude-plugin/plugin.json
@@ -4,26 +4,5 @@
   "description": "Ruby on Rails development toolkit with skills for Rails, Ruby, RSpec, RuboCop, SimpleCov, Brakeman, and code review with Sandi Metz principles",
   "author": {
     "name": "Jeb Coleman"
-  },
-  "commands": [
-    "./commands/rails-generators.md",
-    "./commands/red-green-refactor.md",
-    "./commands/review-ruby-code.md"
-  ],
-  "skills": [
-    "./skills/brakeman",
-    "./skills/postgresql-rails-analyzer",
-    "./skills/rails",
-    "./skills/rails-generators",
-    "./skills/review-ruby-code",
-    "./skills/rspec",
-    "./skills/rubocop",
-    "./skills/ruby",
-    "./skills/rubycritic",
-    "./skills/sandi-metz-reviewer",
-    "./skills/simplecov"
-  ],
-  "agents": [
-    "./agents/rails-generator-agent.md"
-  ]
+  }
 }

--- a/plugins/ruby-rails/skills/cucumber-gherkin/SKILL.md
+++ b/plugins/ruby-rails/skills/cucumber-gherkin/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: cucumber-gherkin
+description: Comprehensive BDD testing with Cucumber and Gherkin syntax. Use when writing feature files (.feature), step definitions, hooks, or implementing Behaviour-Driven Development. Covers Gherkin keywords (Feature, Scenario, Given/When/Then, Background, Scenario Outline, Rule), step definition patterns for Ruby/JavaScript/Java/Python, hooks (Before/After/BeforeAll/AfterAll), tags, data tables, doc strings, and best practices. Triggers on cucumber, gherkin, BDD, feature files, step definitions, acceptance testing, executable specifications.
+---
+
+# Cucumber & Gherkin Skill
+
+BDD testing framework with plain-text executable specifications. Gherkin syntax with step definitions in Ruby, JavaScript, Java, or Python.
+
+## Core Concepts
+
+**Cucumber** reads executable specifications in plain text and validates software behavior. **Gherkin** is the structured grammar making plain text machine-readable.
+
+```
+┌────────────┐                 ┌──────────────┐                 ┌───────────┐
+│   Steps    │                 │     Step     │                 │           │
+│ in Gherkin ├──matched with──>│ Definitions  ├───manipulates──>│  System   │
+└────────────┘                 └──────────────┘                 └───────────┘
+```
+
+## Gherkin Syntax Quick Reference
+
+### Primary Keywords
+
+```gherkin
+Feature: Short description
+  Optional multi-line description explaining the feature.
+  
+  Background:
+    Given common setup steps for all scenarios
+  
+  Rule: Business rule grouping (Gherkin 6+)
+    
+    Scenario: Concrete example illustrating the rule
+      Given an initial context (past tense, setup)
+      When an action occurs (present tense, trigger)
+      Then expected outcome (assertion)
+      And additional step
+      But negative assertion
+    
+    Scenario Outline: Parameterized scenario
+      Given there are <start> items
+      When I remove <remove> items
+      Then I should have <remaining> items
+      
+      Examples:
+        | start | remove | remaining |
+        |    12 |      5 |         7 |
+        |    20 |      5 |        15 |
+```
+
+### Step Keywords
+
+| Keyword | Purpose | Example |
+|---------|---------|---------|
+| `Given` | Setup/precondition | `Given I am logged in as "admin"` |
+| `When` | Action/trigger | `When I click the submit button` |
+| `Then` | Assertion/outcome | `Then I should see "Success"` |
+| `And` | Continue previous type | `And I have 3 items in my cart` |
+| `But` | Negative continuation | `But I should not see "Error"` |
+| `*` | Bullet-style step | `* I have eggs` |
+
+### Data Structures
+
+**Data Tables** - tabular data:
+```gherkin
+Given the following users exist:
+  | name   | email              | role  |
+  | Alice  | alice@example.com  | admin |
+  | Bob    | bob@example.com    | user  |
+```
+
+**Doc Strings** - multi-line text:
+```gherkin
+Given a blog post with content:
+  """markdown
+  # My Post Title
+  
+  This is the content of my blog post.
+  """
+```
+
+### Tags
+
+```gherkin
+@smoke @critical
+Feature: User authentication
+
+  @wip
+  Scenario: Login with valid credentials
+    ...
+  
+  @slow @database
+  Scenario: Bulk user import
+    ...
+```
+
+Tag expressions: `@smoke and not @slow`, `@gui or @api`, `(@smoke or @critical) and not @wip`
+
+## Step Definitions
+
+Match Gherkin steps to code. Use Cucumber Expressions (preferred) or Regular Expressions.
+
+### Ruby
+
+```ruby
+Given('I have {int} cucumbers in my belly') do |count|
+  @belly = Belly.new
+  @belly.eat(count)
+end
+
+When('I wait {int} hour(s)') do |hours|
+  @belly.wait(hours)
+end
+
+Then('my belly should growl') do
+  expect(@belly.growling?).to be true
+end
+
+# With data table
+Given('the following users exist:') do |table|
+  table.hashes.each do |row|
+    User.create!(row)
+  end
+end
+```
+
+### JavaScript
+
+```javascript
+const { Given, When, Then } = require('@cucumber/cucumber');
+
+Given('I have {int} cucumbers in my belly', function(count) {
+  this.belly = new Belly();
+  this.belly.eat(count);
+});
+
+When('I wait {int} hour(s)', async function(hours) {
+  await this.belly.wait(hours);
+});
+
+Then('my belly should growl', function() {
+  expect(this.belly.isGrowling()).toBe(true);
+});
+
+// With data table
+Given('the following users exist:', async function(dataTable) {
+  for (const row of dataTable.hashes()) {
+    await User.create(row);
+  }
+});
+```
+
+### Java
+
+```java
+public class StepDefinitions {
+    @Given("I have {int} cucumbers in my belly")
+    public void iHaveCucumbersInMyBelly(int count) {
+        belly = new Belly();
+        belly.eat(count);
+    }
+    
+    @When("I wait {int} hour(s)")
+    public void iWaitHours(int hours) {
+        belly.wait(hours);
+    }
+    
+    @Then("my belly should growl")
+    public void myBellyShouldGrowl() {
+        assertTrue(belly.isGrowling());
+    }
+}
+```
+
+## Cucumber Expressions
+
+Built-in parameter types: `{int}`, `{float}`, `{word}`, `{string}`, `{}` (anonymous)
+
+Optional text: `cucumber(s)` matches "cucumber" or "cucumbers"
+Alternative text: `color/colour` matches "color" or "colour"
+
+## Hooks
+
+### Scenario Hooks
+
+```ruby
+# Ruby
+Before do |scenario|
+  # runs before each scenario
+end
+
+After do |scenario|
+  # runs after each scenario
+  screenshot if scenario.failed?
+end
+```
+
+```javascript
+// JavaScript
+const { Before, After } = require('@cucumber/cucumber');
+
+Before(async function(scenario) {
+  // runs before each scenario
+});
+
+After(async function(scenario) {
+  // runs after each scenario
+  if (scenario.result.status === 'FAILED') {
+    await this.screenshot();
+  }
+});
+```
+
+### Conditional Hooks (with tags)
+
+```ruby
+Before('@database') do
+  DatabaseCleaner.start
+end
+
+After('@database') do
+  DatabaseCleaner.clean
+end
+```
+
+```javascript
+Before({ tags: '@browser and not @headless' }, async function() {
+  this.browser = await launchBrowser();
+});
+```
+
+### Global Hooks
+
+```ruby
+BeforeAll do
+  # once before any scenario
+end
+
+AfterAll do
+  # once after all scenarios
+end
+```
+
+## Best Practices
+
+### Declarative over Imperative
+
+**Good (declarative):**
+```gherkin
+When "Bob" logs in
+Then he sees his dashboard
+```
+
+**Avoid (imperative):**
+```gherkin
+When I visit "/login"
+And I enter "bob" in "username"
+And I enter "secret" in "password"
+And I click "Login"
+Then I should see "Dashboard"
+```
+
+### Focus on Behavior, Not Implementation
+
+- Describe *what* the system does, not *how*
+- Use domain language stakeholders understand
+- Keep scenarios short (3-5 steps recommended)
+- One behavior per scenario
+
+### Background Usage
+
+- Keep backgrounds short (≤4 lines)
+- Use only for essential shared context
+- Move implementation details to step definitions
+
+## Running Cucumber
+
+```bash
+# Ruby
+bundle exec cucumber
+cucumber --tags "@smoke and not @wip"
+cucumber features/login.feature:10  # specific line
+
+# JavaScript
+npx cucumber-js
+npx cucumber-js --tags "@smoke"
+
+# Java (with Maven)
+mvn test -Dcucumber.filter.tags="@smoke"
+```
+
+## Additional References
+
+For comprehensive details, see reference files:
+
+- `references/gherkin-syntax.md` - Complete Gherkin language reference
+- `references/step-definitions.md` - Step definition patterns by language
+- `references/hooks-config.md` - Hooks, configuration, and runners
+- `references/best-practices.md` - Anti-patterns and advanced patterns

--- a/plugins/ruby-rails/skills/cucumber-gherkin/references/best-practices.md
+++ b/plugins/ruby-rails/skills/cucumber-gherkin/references/best-practices.md
@@ -1,0 +1,476 @@
+# Best Practices and Anti-Patterns
+
+Guidelines for writing effective, maintainable Cucumber tests following BDD principles.
+
+## Core Principles
+
+### 1. Describe Behavior, Not Implementation
+
+Scenarios should describe **what** the system does, not **how** it does it.
+
+**Good:**
+```gherkin
+When Bob logs in with valid credentials
+Then he sees his personalized dashboard
+```
+
+**Bad:**
+```gherkin
+When I enter "bob@test.com" in the email field
+And I enter "password123" in the password field
+And I click the login button
+Then I am redirected to "/dashboard"
+And I see "Welcome, Bob" in the header
+```
+
+**Why it matters:**
+- UI changes shouldn't break behavior specs
+- Stakeholders can understand and verify scenarios
+- Step definitions encapsulate implementation details
+
+### 2. Use Declarative Style Over Imperative
+
+**Declarative** focuses on outcomes and intent. **Imperative** focuses on mechanics.
+
+**Declarative (preferred):**
+```gherkin
+Given Free Frieda has a free subscription
+When she logs in with valid credentials
+Then she sees only free articles
+```
+
+**Imperative (avoid):**
+```gherkin
+Given users with a free subscription can access "FreeArticle1" but not "PaidArticle1"
+When I type "freeFrieda@example.com" in the email field
+And I type "validPassword123" in the password field
+And I press the "Submit" button
+Then I see "FreeArticle1" on the home page
+And I do not see "PaidArticle1" on the home page
+```
+
+### 3. One Behavior Per Scenario
+
+Each scenario should test exactly one behavior or rule.
+
+**Good:**
+```gherkin
+Scenario: Free user cannot access premium content
+  Given I am logged in as a free user
+  When I try to access a premium article
+  Then I see an upgrade prompt
+
+Scenario: Premium user can access all content
+  Given I am logged in as a premium user
+  When I access a premium article
+  Then I see the article content
+```
+
+**Bad:**
+```gherkin
+Scenario: User access levels
+  Given I am logged in as a free user
+  When I try to access a premium article
+  Then I see an upgrade prompt
+  When I upgrade to premium
+  Then I can access the article
+  And I see the download button
+  And my billing shows the charge
+```
+
+### 4. Write from the User's Perspective
+
+Use first-person ("I") or role-based language, not system-centric language.
+
+**Good:**
+```gherkin
+Given I am on the checkout page
+When I apply coupon code "SAVE20"
+Then my total is reduced by 20%
+```
+
+**Bad:**
+```gherkin
+Given the checkout controller receives GET /checkout
+When a POST request with coupon=SAVE20 is sent
+Then the response contains updated_total with 20% reduction
+```
+
+## Scenario Structure
+
+### Keep Scenarios Short
+
+**Target:** 3-5 steps per scenario
+
+```gherkin
+# Good: Focused and readable
+Scenario: Add item to cart
+  Given I am viewing a product
+  When I add it to my cart
+  Then my cart contains 1 item
+
+# Bad: Too long and testing multiple things
+Scenario: Shopping flow
+  Given I am on the home page
+  When I search for "laptop"
+  And I click on the first result
+  And I select "16GB RAM" variant
+  And I click "Add to Cart"
+  Then I see a confirmation
+  When I go to cart
+  Then I see the laptop
+  When I proceed to checkout
+  And I enter shipping address
+  And I enter payment info
+  And I click submit
+  Then I see order confirmation
+```
+
+### Use Background Wisely
+
+**Do:**
+- Keep backgrounds to 4 lines or fewer
+- Use for essential shared context
+- Make names vivid and memorable
+
+**Don't:**
+- Hide important setup (readers should understand scenarios)
+- Use for technical setup (use hooks instead)
+- Duplicate steps that only some scenarios need
+
+```gherkin
+# Good: Vivid, essential context
+Background:
+  Given a global administrator named "Greg"
+  And a blog named "Greg's Soapbox"
+  And a customer named "Dr. Bill"
+
+# Bad: Technical and too long
+Background:
+  Given the database has been seeded
+  And the cache has been cleared
+  And the test user exists with email "test@test.com"
+  And the session timeout is set to 30 minutes
+  And the feature flag "new_checkout" is enabled
+```
+
+### Use Scenario Outlines for Data Variations
+
+```gherkin
+# Good: Single scenario outline for variations
+Scenario Outline: Password validation
+  When I enter password "<password>"
+  Then I should see "<message>"
+  
+  Examples:
+    | password    | message                    |
+    | short       | Password too short         |
+    | nouppercase | Must contain uppercase     |
+    | ValidPass1  | Password accepted          |
+
+# Bad: Repetitive scenarios
+Scenario: Short password rejected
+  When I enter password "short"
+  Then I should see "Password too short"
+
+Scenario: No uppercase rejected
+  When I enter password "nouppercase"
+  Then I should see "Must contain uppercase"
+```
+
+## Step Definition Guidelines
+
+### Single Responsibility
+
+Each step should do one thing.
+
+```ruby
+# Good: Single responsibility
+Given('I have {int} products in stock') do |count|
+  count.times { create(:product, in_stock: true) }
+end
+
+When('I purchase a product') do
+  @purchase = Purchase.create(product: Product.first)
+end
+
+Then('stock is reduced by {int}') do |count|
+  expect(Product.first.stock).to eq(initial_stock - count)
+end
+
+# Bad: Step does too much
+When('I purchase a product and stock is updated') do
+  initial = Product.first.stock
+  Purchase.create(product: Product.first)
+  expect(Product.first.stock).to eq(initial - 1)
+end
+```
+
+### Reusable Steps
+
+Write steps that compose well across scenarios.
+
+```gherkin
+# Reusable building blocks
+Given I am logged in as "admin"
+Given I am logged in as "customer"
+Given I am on the home page
+Given I am on the products page
+When I click "Submit"
+Then I should see "Success"
+Then I should not see "Error"
+```
+
+### Avoid Tight Coupling to UI
+
+```ruby
+# Bad: Tightly coupled to HTML structure
+When('I submit the login form') do
+  find('form#login button[type="submit"]').click
+end
+
+# Good: Uses page object or helper
+When('I submit the login form') do
+  login_page.submit
+end
+
+# Even better: Domain-focused
+When('I log in') do
+  log_in_as(@current_user)
+end
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Scenario as Test Script
+
+❌ Testing implementation, not behavior:
+```gherkin
+Scenario: Login
+  Given I navigate to "/login"
+  When I fill "#email" with "user@test.com"
+  And I fill "#password" with "secret"
+  And I click "#submit-btn"
+  Then "#welcome-msg" should contain "Hello"
+```
+
+✅ Testing behavior:
+```gherkin
+Scenario: Successful login
+  Given I am a registered user
+  When I log in with valid credentials
+  Then I see my personalized greeting
+```
+
+### 2. Incidental Details
+
+❌ Irrelevant specifics:
+```gherkin
+Scenario: Place order
+  Given user "John Smith" with email "john.smith@example.com"
+  And user is at "123 Main Street, Anytown, ST 12345"
+  And user has credit card "4111111111111111" expiring "12/25"
+  When user orders product SKU "WIDGET-001" priced at $19.99
+  Then order #ORD-2024-00001 is created
+```
+
+✅ Essential details only:
+```gherkin
+Scenario: Place order
+  Given John is a registered customer
+  And he has a saved payment method
+  When he orders a widget
+  Then his order is confirmed
+```
+
+### 3. Feature File as Test Suite
+
+❌ One feature, many unrelated scenarios:
+```gherkin
+Feature: User
+  Scenario: User can log in
+  Scenario: User can update profile
+  Scenario: User can view order history
+  Scenario: User can change password
+  Scenario: User can delete account
+```
+
+✅ Focused features:
+```gherkin
+Feature: User Authentication
+  Scenario: Successful login
+  Scenario: Login with invalid password
+  Scenario: Password reset
+
+Feature: User Profile Management
+  Scenario: Update display name
+  Scenario: Update email address
+```
+
+### 4. Cucumber as Integration Test Framework
+
+❌ Testing internal APIs directly:
+```gherkin
+Scenario: API returns 200
+  When I send GET request to "/api/users/1"
+  Then response status is 200
+  And response body contains "id": 1
+```
+
+✅ Testing user-facing behavior (API tests have their place, but consider if Cucumber is the right tool):
+```gherkin
+Scenario: View user profile
+  Given I am viewing my profile
+  Then I see my name and email
+```
+
+### 5. Logic in Feature Files
+
+❌ Conditional logic:
+```gherkin
+Scenario: Login
+  Given I am on the login page
+  When I enter credentials
+  Then if credentials are valid I see dashboard
+  But if credentials are invalid I see error
+```
+
+✅ Separate scenarios:
+```gherkin
+Scenario: Successful login
+  Given I am on the login page
+  When I enter valid credentials
+  Then I see my dashboard
+
+Scenario: Failed login
+  Given I am on the login page
+  When I enter invalid credentials
+  Then I see an error message
+```
+
+## Naming Conventions
+
+### Feature Names
+
+Use noun phrases describing the capability:
+- `User Authentication`
+- `Shopping Cart`
+- `Order Management`
+- `Email Notifications`
+
+### Scenario Names
+
+Use descriptive phrases that explain the behavior:
+- `Successful login with valid credentials`
+- `Add single item to empty cart`
+- `Password reset email sent within 5 minutes`
+
+Avoid:
+- `Test login` (too vague)
+- `TC-001: Login` (test case IDs belong in tags)
+- `Should work` (meaningless)
+
+### Tag Conventions
+
+```gherkin
+# Categories
+@smoke @regression @e2e
+
+# Priority
+@critical @high @low
+
+# Status
+@wip @pending @manual
+
+# Technical
+@slow @database @browser @api
+
+# External references
+@JIRA-123 @story-456
+```
+
+## Collaboration Patterns
+
+### Three Amigos
+
+Before writing scenarios:
+1. **Product Owner:** Explains the feature and acceptance criteria
+2. **Developer:** Identifies technical considerations
+3. **Tester:** Asks about edge cases and test scenarios
+
+### Example Mapping
+
+Use colored cards to organize discussions:
+- **Yellow (Story):** The feature or user story
+- **Blue (Rules):** Business rules
+- **Green (Examples):** Concrete scenarios
+- **Red (Questions):** Uncertainties to resolve
+
+### Living Documentation
+
+Treat feature files as documentation:
+- Keep them up to date with the system
+- Use meaningful descriptions
+- Include enough context for new team members
+- Review and refactor regularly
+
+## Performance Considerations
+
+### Fast Feedback
+
+```ruby
+# Use faster alternatives when possible
+Before do
+  # Fast: Create test data directly
+  @user = create(:user)
+  
+  # Slow: Go through UI to create user
+  visit new_user_path
+  fill_in 'Email', with: 'test@test.com'
+  click_button 'Create'
+end
+```
+
+### Tag-Based Execution
+
+```bash
+# Run only smoke tests for quick feedback
+cucumber --tags @smoke
+
+# Skip slow tests during development
+cucumber --tags "not @slow"
+
+# Run database tests in isolation
+cucumber --tags @database
+```
+
+### Parallel Execution
+
+```bash
+# Ruby with parallel_tests
+bundle exec parallel_cucumber features/
+
+# JavaScript
+npx cucumber-js --parallel 4
+
+# Java with Maven
+mvn test -T 4  # 4 threads
+```
+
+## Refactoring Scenarios
+
+### When to Refactor
+
+- Scenarios are too long (>7 steps)
+- Multiple scenarios have duplicated steps
+- Scenarios test implementation, not behavior
+- Hard to understand without reading step definitions
+- Feature files don't match current system behavior
+
+### Safe Refactoring Process
+
+1. Ensure all scenarios pass
+2. Make small, incremental changes
+3. Run tests after each change
+4. Update step definitions to match new wording
+5. Review with team for clarity

--- a/plugins/ruby-rails/skills/cucumber-gherkin/references/gherkin-syntax.md
+++ b/plugins/ruby-rails/skills/cucumber-gherkin/references/gherkin-syntax.md
@@ -1,0 +1,382 @@
+# Gherkin Syntax Reference
+
+Complete reference for Gherkin language syntax used in Cucumber feature files.
+
+## Document Structure
+
+Every `.feature` file must begin with a `Feature` keyword. The structure is:
+
+```gherkin
+# language: en (optional, defaults to English)
+@feature-tag
+Feature: Feature name
+  Optional description that can span
+  multiple lines.
+  
+  Background:
+    Given shared setup steps
+  
+  Rule: Business rule description
+    Background:
+      Given rule-specific setup
+    
+    Scenario: Example name
+      Given precondition
+      When action
+      Then outcome
+```
+
+## Keywords Reference
+
+### Feature
+
+The root keyword. One per file. Provides high-level description and groups scenarios.
+
+```gherkin
+Feature: User Registration
+  As a visitor
+  I want to create an account
+  So that I can access member features
+  
+  Scenario: Successful registration
+    ...
+```
+
+Free-form text after `Feature:` is ignored by Cucumber but included in reports.
+
+### Rule (Gherkin 6+)
+
+Groups scenarios under a business rule. Supports tag inheritance.
+
+```gherkin
+Feature: Highlander
+  
+  Rule: There can be only One
+    
+    Example: Only One -- More than one alive
+      Given there are 3 ninjas
+      When 2 ninjas meet, they will fight
+      Then one ninja dies
+    
+    Example: Only One -- One alive
+      Given there is only 1 ninja alive
+      Then they will live forever
+  
+  Rule: There can be Two (in some cases)
+    
+    Example: Two -- Phoenix resurrection
+      ...
+```
+
+### Scenario / Example
+
+Concrete example illustrating expected behavior. `Example` and `Scenario` are synonyms.
+
+```gherkin
+Scenario: Add item to cart
+  Given I am viewing a product
+  When I click "Add to Cart"
+  Then my cart should contain 1 item
+```
+
+Best practice: 3-5 steps per scenario. More indicates the scenario may be testing multiple behaviors.
+
+### Background
+
+Shared setup steps run before each scenario in the feature (or rule).
+
+```gherkin
+Feature: Blog management
+  
+  Background:
+    Given I am logged in as "editor"
+    And I am on the blog admin page
+  
+  Scenario: Create post
+    When I create a new post
+    Then ...
+  
+  Scenario: Delete post
+    When I delete an existing post
+    Then ...
+```
+
+Background runs after `Before` hooks but before scenario steps.
+
+**Best practices:**
+- Keep to 4 lines or fewer
+- Use only for essential context visible to readers
+- Don't use for technical setup (put in hooks instead)
+- Make it vivid with meaningful names
+
+### Scenario Outline / Scenario Template
+
+Run same scenario with different data combinations. Uses `< >` placeholders.
+
+```gherkin
+Scenario Outline: Eating cucumbers
+  Given there are <start> cucumbers
+  When I eat <eat> cucumbers
+  Then I should have <left> cucumbers
+  
+  Examples: Normal appetite
+    | start | eat | left |
+    |    12 |   5 |    7 |
+    |    20 |   5 |   15 |
+  
+  Examples: Big appetite
+    | start | eat | left |
+    |    50 |  20 |   30 |
+```
+
+Parameters can appear in step text, doc strings, and data tables.
+
+### Examples / Scenarios
+
+Data table for Scenario Outline. Each row generates one scenario execution.
+
+```gherkin
+Scenario Outline: Login validation
+  When I login with "<email>" and "<password>"
+  Then I should see "<message>"
+  
+  @valid
+  Examples: Valid credentials
+    | email           | password | message         |
+    | user@test.com   | secret   | Welcome back    |
+  
+  @invalid
+  Examples: Invalid credentials
+    | email           | password | message         |
+    | user@test.com   | wrong    | Invalid login   |
+    | bad@format      | any      | Invalid email   |
+```
+
+Tags on Examples apply only to scenarios generated from that table.
+
+## Step Keywords
+
+### Given
+
+Describes initial context. Use past tense. Sets up the system state.
+
+```gherkin
+Given I am logged in as "admin"
+Given the following products exist:
+  | name   | price |
+  | Widget | 9.99  |
+Given today is "2024-01-15"
+```
+
+### When
+
+Describes the action or event being tested. Use present tense.
+
+```gherkin
+When I click "Submit"
+When I search for "cucumber"
+When the system processes the batch job
+When 24 hours pass
+```
+
+**Tip:** Imagine it's 1922 - describe what happens, not which buttons are clicked.
+
+### Then
+
+Describes expected outcome. Should use assertions.
+
+```gherkin
+Then I should see "Success"
+Then the order status should be "confirmed"
+Then my cart should contain 3 items
+Then an email should be sent to "user@test.com"
+```
+
+Outcomes should be **observable** - something the user can see, not internal state.
+
+### And / But
+
+Continue the previous step type for readability.
+
+```gherkin
+Given I am logged in
+  And I have items in my cart
+  And my shipping address is set
+
+When I proceed to checkout
+  And I select "Express Shipping"
+
+Then I should see the order summary
+  And the total should include shipping
+  But I should not see any errors
+```
+
+### * (Asterisk)
+
+Generic step marker. Useful for bullet-point lists.
+
+```gherkin
+Scenario: Shopping list
+  Given I am out shopping
+  * I have eggs
+  * I have milk
+  * I have butter
+  When I check my list
+  Then I don't need anything
+```
+
+## Step Arguments
+
+### Data Tables
+
+Pass tabular data to step definitions.
+
+```gherkin
+# Simple list (single column)
+Given the following users:
+  | alice   |
+  | bob     |
+  | charlie |
+
+# Key-value pairs (two columns)
+Given a user with attributes:
+  | name  | Alice           |
+  | email | alice@test.com  |
+  | role  | admin           |
+
+# Records (header row + data rows)
+Given these products exist:
+  | name   | price | stock |
+  | Widget | 9.99  |    50 |
+  | Gadget | 19.99 |    25 |
+```
+
+**Escaping in tables:**
+- `\n` - newline
+- `\|` - literal pipe
+- `\\` - literal backslash
+
+### Doc Strings
+
+Multi-line text blocks using triple quotes.
+
+```gherkin
+Given a blog post with Markdown body:
+  """
+  # Welcome
+  
+  This is my **first** post.
+  """
+
+Given a JSON request body:
+  """json
+  {
+    "name": "Test",
+    "active": true
+  }
+  """
+```
+
+Content type annotation (e.g., `"""json`) is optional but helpful for syntax highlighting.
+
+Indentation: Opening `"""` sets the baseline. Content is dedented accordingly.
+
+## Tags
+
+Labels for organizing and filtering features/scenarios.
+
+```gherkin
+@billing @important
+Feature: Invoice generation
+  
+  @smoke
+  Scenario: Generate invoice
+    ...
+  
+  @slow @nightly
+  Scenario: Generate annual report
+    ...
+```
+
+### Tag Placement
+
+Tags can be placed above:
+- `Feature`
+- `Rule`
+- `Scenario` / `Example`
+- `Scenario Outline`
+- `Examples`
+
+**Cannot** tag: `Background`, individual steps
+
+### Tag Inheritance
+
+Child elements inherit parent tags:
+- Scenarios inherit Feature tags
+- Scenarios in Rules inherit both Rule and Feature tags
+- Examples inherit Scenario Outline tags
+
+```gherkin
+@feature-tag
+Feature: Example
+  
+  @rule-tag
+  Rule: Business rule
+    
+    @scenario-tag
+    Scenario: Test
+      # Has: @feature-tag, @rule-tag, @scenario-tag
+```
+
+### Tag Expressions
+
+Boolean expressions for filtering:
+
+| Expression | Matches |
+|------------|---------|
+| `@smoke` | Tagged with @smoke |
+| `@smoke and @fast` | Tagged with both |
+| `@smoke or @critical` | Tagged with either |
+| `not @wip` | Not tagged with @wip |
+| `@smoke and not @slow` | @smoke but not @slow |
+| `(@smoke or @critical) and not @wip` | Complex combination |
+
+## Comments
+
+Single-line comments start with `#`.
+
+```gherkin
+Feature: User login
+  # This feature covers authentication flows
+  
+  Scenario: Valid login
+    # TODO: Add two-factor auth step
+    Given I am on the login page
+```
+
+Block comments are not supported.
+
+## Spoken Languages
+
+Gherkin supports 70+ languages. Specify with `# language:` directive.
+
+```gherkin
+# language: fr
+Fonctionnalité: Connexion utilisateur
+  
+  Scénario: Connexion réussie
+    Etant donné je suis sur la page de connexion
+    Quand je saisis mes identifiants
+    Alors je vois mon tableau de bord
+```
+
+```gherkin
+# language: no
+Funksjonalitet: Gjett et ord
+  
+  Eksempel: Ordmaker starter et spill
+    Når Ordmaker starter et spill
+    Så må Ordmaker vente på at Gjetter blir med
+```
+
+If omitted, defaults to English (`en`). Can also be set in Cucumber configuration.

--- a/plugins/ruby-rails/skills/cucumber-gherkin/references/hooks-config.md
+++ b/plugins/ruby-rails/skills/cucumber-gherkin/references/hooks-config.md
@@ -1,0 +1,622 @@
+# Hooks and Configuration Reference
+
+Hooks are blocks of code that run at specific points in the Cucumber execution cycle. This reference covers hooks, configuration, and test runners.
+
+## Hooks Overview
+
+| Hook | Scope | Runs |
+|------|-------|------|
+| `BeforeAll` | Global | Once before any scenario |
+| `AfterAll` | Global | Once after all scenarios |
+| `Before` | Scenario | Before each scenario |
+| `After` | Scenario | After each scenario |
+| `BeforeStep` | Step | Before each step |
+| `AfterStep` | Step | After each step |
+| `Around` | Scenario | Wraps scenario (Ruby only) |
+
+## Scenario Hooks
+
+### Before Hook
+
+Runs before the first step of each scenario.
+
+**Ruby:**
+```ruby
+Before do |scenario|
+  @browser = Browser.new
+end
+
+# With tag filter
+Before('@browser') do
+  start_browser
+end
+
+# With explicit order (lower runs first)
+Before(order: 10) do
+  setup_database
+end
+
+Before(order: 20) do
+  seed_data
+end
+```
+
+**JavaScript:**
+```javascript
+const { Before } = require('@cucumber/cucumber');
+
+Before(async function(scenario) {
+  this.browser = await launchBrowser();
+});
+
+// With tag filter
+Before({ tags: '@browser' }, async function() {
+  await this.startBrowser();
+});
+
+// With order
+Before({ order: 10 }, async function() {
+  await this.setupDatabase();
+});
+```
+
+**Java:**
+```java
+@Before
+public void beforeScenario(Scenario scenario) {
+    browser = new Browser();
+}
+
+@Before("@browser")
+public void beforeBrowserScenario() {
+    startBrowser();
+}
+
+@Before(order = 10)
+public void setupDatabase() {
+    // runs first
+}
+```
+
+### After Hook
+
+Runs after the last step of each scenario, regardless of outcome.
+
+**Ruby:**
+```ruby
+After do |scenario|
+  if scenario.failed?
+    save_screenshot("failure_#{scenario.name}.png")
+  end
+  @browser.quit
+end
+
+After('@database') do
+  DatabaseCleaner.clean
+end
+```
+
+**JavaScript:**
+```javascript
+const { After, Status } = require('@cucumber/cucumber');
+
+After(async function(scenario) {
+  if (scenario.result.status === Status.FAILED) {
+    const screenshot = await this.page.screenshot();
+    this.attach(screenshot, 'image/png');
+  }
+  await this.browser.close();
+});
+
+After({ tags: '@database' }, async function() {
+  await this.cleanDatabase();
+});
+```
+
+**Java:**
+```java
+@After
+public void afterScenario(Scenario scenario) {
+    if (scenario.isFailed()) {
+        byte[] screenshot = driver.getScreenshotAs(OutputType.BYTES);
+        scenario.attach(screenshot, "image/png", "failure");
+    }
+    driver.quit();
+}
+```
+
+### Around Hook (Ruby Only)
+
+Wraps scenario execution. Useful for timeout control.
+
+```ruby
+Around('@fast') do |scenario, block|
+  Timeout.timeout(0.5) do
+    block.call
+  end
+end
+
+Around do |scenario, block|
+  start_time = Time.now
+  block.call
+  puts "Scenario took #{Time.now - start_time}s"
+end
+```
+
+## Step Hooks
+
+Run before/after each step. Useful for debugging.
+
+**Ruby:**
+```ruby
+# AfterStep only in Ruby
+AfterStep do |scenario|
+  puts "Just finished a step"
+end
+```
+
+**JavaScript:**
+```javascript
+const { BeforeStep, AfterStep } = require('@cucumber/cucumber');
+
+BeforeStep(async function({ pickle, pickleStep }) {
+  console.log(`Starting: ${pickleStep.text}`);
+});
+
+AfterStep(async function({ pickle, pickleStep, result }) {
+  console.log(`Finished: ${pickleStep.text} - ${result.status}`);
+});
+
+// With tag filter
+BeforeStep({ tags: '@debug' }, async function() {
+  await this.logState();
+});
+```
+
+**Java:**
+```java
+@BeforeStep
+public void beforeStep(Scenario scenario) {
+    // runs before each step
+}
+
+@AfterStep
+public void afterStep(Scenario scenario) {
+    // runs after each step
+}
+```
+
+## Global Hooks
+
+Run once for entire test suite.
+
+**Ruby:**
+```ruby
+# In features/support/env.rb
+BeforeAll do
+  DatabaseCleaner.strategy = :truncation
+  start_server
+end
+
+AfterAll do
+  stop_server
+end
+```
+
+**JavaScript:**
+```javascript
+const { BeforeAll, AfterAll } = require('@cucumber/cucumber');
+
+BeforeAll(async function() {
+  await startDatabase();
+});
+
+AfterAll(async function() {
+  await stopDatabase();
+});
+```
+
+**Java:**
+```java
+public class Hooks {
+    @BeforeAll
+    public static void beforeAll() {
+        // must be static
+        startServer();
+    }
+    
+    @AfterAll
+    public static void afterAll() {
+        stopServer();
+    }
+}
+```
+
+## Conditional Hooks
+
+Use tag expressions to run hooks selectively.
+
+```ruby
+Before('@browser and not @headless') do
+  @browser = Browser.new(headless: false)
+end
+
+After('@database') do
+  DatabaseCleaner.clean
+end
+
+Before('@smoke or @critical') do
+  setup_monitoring
+end
+```
+
+```javascript
+Before({ tags: '@browser and not @headless' }, async function() {
+  this.browser = await launchBrowser({ headless: false });
+});
+
+Before({ tags: '@smoke or @critical' }, async function() {
+  await this.setupMonitoring();
+});
+```
+
+## Hook Execution Order
+
+1. `BeforeAll` hooks (once)
+2. For each scenario:
+   - `Before` hooks (in order of registration, or by `order` param)
+   - `Background` steps (if any)
+   - Scenario steps (with `BeforeStep`/`AfterStep` around each)
+   - `After` hooks (in reverse order of registration)
+3. `AfterAll` hooks (once)
+
+## Configuration
+
+### Ruby (cucumber.yml)
+
+```yaml
+# config/cucumber.yml
+default: --format progress --strict --tags "not @wip"
+html_report: --format html --out reports/cucumber.html
+ci: --format progress --format junit --out reports/junit.xml --tags "not @wip"
+smoke: --tags @smoke
+```
+
+Usage:
+```bash
+cucumber                    # uses default profile
+cucumber -p html_report     # uses html_report profile
+cucumber -p ci              # uses ci profile
+```
+
+### JavaScript (cucumber.js)
+
+```javascript
+// cucumber.js
+module.exports = {
+  default: {
+    require: ['features/step_definitions/**/*.js', 'features/support/**/*.js'],
+    format: ['progress', 'html:reports/cucumber.html'],
+    formatOptions: { snippetInterface: 'async-await' },
+    publishQuiet: true
+  },
+  smoke: {
+    require: ['features/step_definitions/**/*.js'],
+    tags: '@smoke'
+  }
+};
+```
+
+Usage:
+```bash
+npx cucumber-js               # uses default
+npx cucumber-js -p smoke      # uses smoke profile
+```
+
+### Java (cucumber.properties)
+
+```properties
+# src/test/resources/cucumber.properties
+cucumber.ansi-colors.disabled=false
+cucumber.execution.dry-run=false
+cucumber.execution.order=lexical
+cucumber.filter.tags=not @wip
+cucumber.glue=com.example.steps
+cucumber.plugin=pretty,html:target/cucumber.html
+cucumber.snippet-type=underscore
+```
+
+### Java (JUnit 4 Runner)
+
+```java
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    features = "src/test/resources/features",
+    glue = {"com.example.steps", "com.example.hooks"},
+    plugin = {"pretty", "html:target/cucumber.html", "json:target/cucumber.json"},
+    tags = "not @wip",
+    monochrome = true,
+    dryRun = false
+)
+public class RunCucumberTest {
+}
+```
+
+### Java (JUnit 5 Platform)
+
+```java
+// src/test/resources/junit-platform.properties
+cucumber.glue=com.example.steps
+cucumber.plugin=pretty,html:target/cucumber.html
+cucumber.filter.tags=not @wip
+
+// Or in pom.xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <configuration>
+        <systemPropertyVariables>
+            <cucumber.filter.tags>@smoke</cucumber.filter.tags>
+        </systemPropertyVariables>
+    </configuration>
+</plugin>
+```
+
+## Running Cucumber
+
+### Ruby
+
+```bash
+# Run all features
+bundle exec cucumber
+
+# Run specific feature
+cucumber features/login.feature
+
+# Run specific scenario by line
+cucumber features/login.feature:10
+
+# Run with tags
+cucumber --tags "@smoke and not @wip"
+
+# Dry run (check step definitions without executing)
+cucumber --dry-run
+
+# Generate HTML report
+cucumber --format html --out report.html
+
+# Parallel execution
+bundle exec parallel_cucumber features/
+```
+
+### JavaScript
+
+```bash
+# Run all features
+npx cucumber-js
+
+# Run specific feature
+npx cucumber-js features/login.feature
+
+# Run with tags
+npx cucumber-js --tags "@smoke and not @wip"
+
+# With specific format
+npx cucumber-js --format progress
+
+# Parallel execution (requires cucumber-parallel)
+npx cucumber-js --parallel 4
+```
+
+### Java (Maven)
+
+```bash
+# Run all tests
+mvn test
+
+# Run with specific tags
+mvn test -Dcucumber.filter.tags="@smoke"
+
+# Run specific feature file
+mvn test -Dcucumber.features="src/test/resources/features/login.feature"
+
+# Dry run
+mvn test -Dcucumber.execution.dry-run=true
+
+# Generate reports
+mvn verify  # runs cucumber and generates reports
+```
+
+### Java (Gradle)
+
+```groovy
+// build.gradle
+test {
+    systemProperty 'cucumber.filter.tags', '@smoke'
+    systemProperty 'cucumber.plugin', 'pretty,html:build/reports/cucumber.html'
+}
+```
+
+```bash
+gradle test
+```
+
+## Reporter Plugins
+
+### Built-in Formatters
+
+| Format | Description |
+|--------|-------------|
+| `pretty` | Colored console output |
+| `progress` | Dots for passed, F for failed |
+| `html:path` | HTML report |
+| `json:path` | JSON output |
+| `junit:path` | JUnit XML format |
+| `message:path` | Cucumber Messages (Protobuf) |
+
+### Using Multiple Formatters
+
+```bash
+# Ruby
+cucumber --format progress --format html --out report.html
+
+# JavaScript
+npx cucumber-js --format progress --format html:report.html
+
+# Java
+@CucumberOptions(
+    plugin = {"progress", "html:target/cucumber.html", "json:target/cucumber.json"}
+)
+```
+
+## World/Context Pattern
+
+Share state between steps in a scenario.
+
+### Ruby
+
+```ruby
+# features/support/world.rb
+module CustomWorld
+  attr_accessor :current_user
+  
+  def login_as(user)
+    @current_user = user
+    visit login_path
+    fill_in 'email', with: user.email
+    click_button 'Login'
+  end
+end
+
+World(CustomWorld)
+
+# In step definitions
+Given('I am logged in as {string}') do |email|
+  self.current_user = User.find_by(email: email)
+  login_as(current_user)
+end
+```
+
+### JavaScript
+
+```javascript
+// features/support/world.js
+const { setWorldConstructor } = require('@cucumber/cucumber');
+
+class CustomWorld {
+  constructor({ attach, log, parameters }) {
+    this.attach = attach;
+    this.log = log;
+    this.parameters = parameters;
+    this.currentUser = null;
+  }
+  
+  async loginAs(user) {
+    this.currentUser = user;
+    await this.page.goto('/login');
+    await this.page.fill('#email', user.email);
+    await this.page.click('button[type="submit"]');
+  }
+}
+
+setWorldConstructor(CustomWorld);
+
+// In step definitions
+Given('I am logged in as {string}', async function(email) {
+  const user = await User.findByEmail(email);
+  await this.loginAs(user);
+});
+```
+
+### Java (Dependency Injection)
+
+```java
+// SharedState.java (PicoContainer injects same instance to all step classes)
+public class SharedState {
+    private User currentUser;
+    private WebDriver driver;
+    
+    public User getCurrentUser() { return currentUser; }
+    public void setCurrentUser(User user) { this.currentUser = user; }
+    // getters/setters...
+}
+
+// UserSteps.java
+public class UserSteps {
+    private final SharedState state;
+    
+    public UserSteps(SharedState state) {
+        this.state = state;
+    }
+    
+    @Given("I am logged in as {string}")
+    public void loginAs(String email) {
+        User user = userService.findByEmail(email);
+        state.setCurrentUser(user);
+        loginPage.loginAs(user);
+    }
+}
+```
+
+## Environment Variables
+
+Access environment-specific configuration.
+
+```ruby
+# Ruby
+Before do
+  @base_url = ENV['BASE_URL'] || 'http://localhost:3000'
+end
+```
+
+```javascript
+// JavaScript
+Before(function() {
+  this.baseUrl = process.env.BASE_URL || 'http://localhost:3000';
+});
+```
+
+```java
+// Java
+@Before
+public void setup() {
+    baseUrl = System.getenv().getOrDefault("BASE_URL", "http://localhost:3000");
+}
+```
+
+## Screenshot on Failure
+
+Common pattern for browser tests.
+
+```ruby
+# Ruby with Capybara
+After do |scenario|
+  if scenario.failed?
+    page.save_screenshot("tmp/screenshots/#{scenario.name.gsub(/\s+/, '_')}.png")
+    embed("tmp/screenshots/#{scenario.name.gsub(/\s+/, '_')}.png", 'image/png')
+  end
+end
+```
+
+```javascript
+// JavaScript with Playwright
+const { After, Status } = require('@cucumber/cucumber');
+
+After(async function(scenario) {
+  if (scenario.result.status === Status.FAILED) {
+    const screenshot = await this.page.screenshot();
+    await this.attach(screenshot, 'image/png');
+  }
+});
+```
+
+```java
+// Java with Selenium
+@After
+public void takeScreenshotOnFailure(Scenario scenario) {
+    if (scenario.isFailed()) {
+        byte[] screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+        scenario.attach(screenshot, "image/png", "Screenshot on failure");
+    }
+}
+```

--- a/plugins/ruby-rails/skills/cucumber-gherkin/references/step-definitions.md
+++ b/plugins/ruby-rails/skills/cucumber-gherkin/references/step-definitions.md
@@ -1,0 +1,607 @@
+# Step Definitions Reference
+
+Step definitions connect Gherkin steps to executable code. This reference covers patterns for Ruby, JavaScript, Java, Kotlin, Scala, and Python.
+
+## How Matching Works
+
+1. Cucumber reads a Gherkin step (e.g., `Given I have 48 cukes`)
+2. Searches registered step definitions for a matching expression
+3. Extracts capture groups / parameters
+4. Executes the matched method with extracted values
+
+**Important:** Keywords (`Given`, `When`, `Then`) are ignored during matching. These steps would conflict:
+```gherkin
+Given there is money in my account
+Then there is money in my account  # Same text = duplicate!
+```
+
+## Cucumber Expressions vs Regular Expressions
+
+### Cucumber Expressions (Preferred)
+
+Human-readable, type-safe parameter matching:
+
+```
+I have {int} cukes in my belly
+I have {float} dollars
+I am logged in as {string}
+the user {word} is active
+```
+
+**Built-in parameter types:**
+
+| Type | Matches | Example |
+|------|---------|---------|
+| `{int}` | Integers | `42`, `-17` |
+| `{float}` | Decimals | `3.14`, `-0.5` |
+| `{word}` | Single word (no whitespace) | `admin` |
+| `{string}` | Quoted string | `"hello"` or `'hello'` |
+| `{}` | Anonymous (any text) | Anything |
+| `{bigdecimal}` | Arbitrary precision | `123.456789` |
+| `{biginteger}` | Large integers | `999999999999` |
+
+**Optional text:** Parentheses make text optional
+```
+I have {int} cucumber(s)  # matches "cucumber" or "cucumbers"
+I wait {int} second(s)
+```
+
+**Alternative text:** Slash for alternatives
+```
+I am on the home/login/dashboard page
+his/her/their account
+```
+
+### Regular Expressions
+
+Use when Cucumber Expressions are insufficient:
+
+```ruby
+Given(/^I have (\d+) cukes? in my belly$/) do |count|
+  # ...
+end
+```
+
+## Ruby Step Definitions
+
+### Basic Steps
+
+```ruby
+Given('I am on the home page') do
+  visit root_path
+end
+
+When('I click {string}') do |text|
+  click_on text
+end
+
+Then('I should see {string}') do |text|
+  expect(page).to have_content(text)
+end
+```
+
+### With Parameters
+
+```ruby
+Given('there are {int} products') do |count|
+  count.times { create(:product) }
+end
+
+When('I transfer {float} dollars') do |amount|
+  @account.transfer(amount)
+end
+
+Then('the user {string} should be {word}') do |name, status|
+  expect(User.find_by(name: name).status).to eq(status)
+end
+```
+
+### Data Tables
+
+```ruby
+# Simple list (single column)
+Given('the following tags:') do |table|
+  tags = table.raw.flatten  # ["ruby", "cucumber", "testing"]
+  tags.each { |tag| Tag.create!(name: tag) }
+end
+
+# Key-value pairs (two columns)
+Given('a user with:') do |table|
+  attributes = table.rows_hash  # {"name"=>"Alice", "email"=>"a@test.com"}
+  User.create!(attributes)
+end
+
+# Table with headers
+Given('the following products:') do |table|
+  table.hashes.each do |row|
+    # row = {"name"=>"Widget", "price"=>"9.99", "stock"=>"50"}
+    Product.create!(row)
+  end
+end
+
+# Symbolic keys
+Given('products exist:') do |table|
+  table.symbolic_hashes.each do |row|
+    # row = {name: "Widget", price: "9.99"}
+    Product.create!(row)
+  end
+end
+```
+
+### Doc Strings
+
+```ruby
+Given('a blog post with content:') do |content|
+  # content is the full doc string text
+  @post = Post.create!(body: content)
+end
+
+Given('a JSON payload:') do |json|
+  @payload = JSON.parse(json)
+end
+```
+
+### Sharing State
+
+```ruby
+# Use instance variables
+Given('I have a user') do
+  @user = create(:user)
+end
+
+When('the user logs in') do
+  login_as(@user)
+end
+
+# Or use a World module
+module MyWorld
+  def current_user
+    @current_user ||= create(:user)
+  end
+end
+
+World(MyWorld)
+
+Given('I am logged in') do
+  login_as(current_user)
+end
+```
+
+## JavaScript Step Definitions
+
+### Basic Steps
+
+```javascript
+const { Given, When, Then } = require('@cucumber/cucumber');
+const { expect } = require('chai');
+
+Given('I am on the home page', async function() {
+  await this.page.goto('/');
+});
+
+When('I click {string}', async function(text) {
+  await this.page.click(`text=${text}`);
+});
+
+Then('I should see {string}', async function(text) {
+  const content = await this.page.textContent('body');
+  expect(content).to.include(text);
+});
+```
+
+**Important:** Avoid arrow functions - they bind `this` incorrectly.
+
+### With Parameters
+
+```javascript
+Given('there are {int} products', async function(count) {
+  for (let i = 0; i < count; i++) {
+    await this.createProduct();
+  }
+});
+
+When('I transfer {float} dollars', async function(amount) {
+  await this.account.transfer(amount);
+});
+```
+
+### Data Tables
+
+```javascript
+Given('the following users:', async function(dataTable) {
+  // As array of hashes
+  const users = dataTable.hashes();
+  // [{ name: 'Alice', email: 'alice@test.com' }, ...]
+  
+  for (const user of users) {
+    await User.create(user);
+  }
+});
+
+Given('a user with:', async function(dataTable) {
+  // Two-column table as object
+  const attrs = dataTable.rowsHash();
+  // { name: 'Alice', email: 'alice@test.com' }
+  
+  await User.create(attrs);
+});
+
+Given('the following tags:', async function(dataTable) {
+  // Single column as flat array
+  const tags = dataTable.raw().flat();
+  // ['ruby', 'cucumber', 'testing']
+});
+```
+
+### Doc Strings
+
+```javascript
+Given('a JSON payload:', async function(docString) {
+  this.payload = JSON.parse(docString);
+});
+
+Given('an email with body:', async function(body) {
+  this.email = { body };
+});
+```
+
+### Async/Await and Promises
+
+```javascript
+// Async/await (preferred)
+When('I wait for the page to load', async function() {
+  await this.page.waitForLoadState('networkidle');
+});
+
+// Promise
+Then('the API returns success', function() {
+  return this.api.getStatus().then(status => {
+    expect(status).to.equal('ok');
+  });
+});
+
+// Callback (legacy)
+Given('I wait {int} seconds', function(seconds, callback) {
+  setTimeout(callback, seconds * 1000);
+});
+```
+
+### World Context
+
+```javascript
+// features/support/world.js
+const { setWorldConstructor } = require('@cucumber/cucumber');
+
+class CustomWorld {
+  constructor() {
+    this.users = [];
+  }
+  
+  async createUser(attrs) {
+    const user = await User.create(attrs);
+    this.users.push(user);
+    return user;
+  }
+}
+
+setWorldConstructor(CustomWorld);
+
+// In step definitions
+Given('a user exists', async function() {
+  this.currentUser = await this.createUser({ name: 'Test' });
+});
+```
+
+## Java Step Definitions
+
+### Basic Steps
+
+```java
+package com.example.steps;
+
+import io.cucumber.java.en.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StepDefinitions {
+    
+    @Given("I am on the home page")
+    public void iAmOnTheHomePage() {
+        driver.get(baseUrl);
+    }
+    
+    @When("I click {string}")
+    public void iClick(String text) {
+        driver.findElement(By.linkText(text)).click();
+    }
+    
+    @Then("I should see {string}")
+    public void iShouldSee(String text) {
+        assertTrue(driver.getPageSource().contains(text));
+    }
+}
+```
+
+### Lambda Style (Java 8+)
+
+```java
+import io.cucumber.java8.En;
+
+public class LambdaSteps implements En {
+    
+    public LambdaSteps() {
+        Given("I am on the home page", () -> {
+            driver.get(baseUrl);
+        });
+        
+        When("I click {string}", (String text) -> {
+            driver.findElement(By.linkText(text)).click();
+        });
+        
+        Then("I should see {string}", (String text) -> {
+            assertTrue(driver.getPageSource().contains(text));
+        });
+    }
+}
+```
+
+### Data Tables
+
+```java
+@Given("the following users:")
+public void theFollowingUsers(DataTable dataTable) {
+    // As list of maps
+    List<Map<String, String>> users = dataTable.asMaps();
+    
+    // As list of lists
+    List<List<String>> rows = dataTable.asLists();
+    
+    // With custom type conversion
+    List<User> users = dataTable.asList(User.class);
+}
+
+@Given("a user with:")
+public void aUserWith(DataTable dataTable) {
+    Map<String, String> attrs = dataTable.asMap();
+    // {name=Alice, email=alice@test.com}
+}
+```
+
+### Doc Strings
+
+```java
+@Given("a JSON payload:")
+public void aJsonPayload(String docString) {
+    this.payload = new ObjectMapper().readValue(docString, Map.class);
+}
+```
+
+### Dependency Injection
+
+```java
+// With PicoContainer
+public class StepDefinitions {
+    private final SharedState state;
+    
+    public StepDefinitions(SharedState state) {
+        this.state = state;
+    }
+    
+    @Given("I have a user")
+    public void iHaveAUser() {
+        state.setCurrentUser(new User("Test"));
+    }
+}
+
+// With Spring
+@CucumberContextConfiguration
+@SpringBootTest
+public class SpringStepDefinitions {
+    @Autowired
+    private UserService userService;
+    
+    @Given("I have a user")
+    public void iHaveAUser() {
+        userService.createUser("Test");
+    }
+}
+```
+
+## Kotlin Step Definitions
+
+```kotlin
+import io.cucumber.java8.En
+
+class StepDefinitions : En {
+    
+    init {
+        Given("I have {int} cukes") { count: Int ->
+            belly.eat(count)
+        }
+        
+        When("I wait {int} hours") { hours: Int ->
+            belly.wait(hours)
+        }
+        
+        Then("my belly should growl") {
+            assertTrue(belly.isGrowling)
+        }
+    }
+}
+```
+
+**Note:** `@BeforeAll`/`@AfterAll` in companion objects causes issues. Use package-level functions:
+
+```kotlin
+package com.example
+
+import io.cucumber.java.BeforeAll
+import io.cucumber.java.AfterAll
+
+@BeforeAll
+fun beforeAll() {
+    println("Setup")
+}
+
+@AfterAll
+fun afterAll() {
+    println("Teardown")
+}
+```
+
+## Python Step Definitions (Behave)
+
+```python
+from behave import given, when, then
+
+@given('I am on the home page')
+def step_on_home_page(context):
+    context.browser.get(context.base_url)
+
+@when('I click "{text}"')
+def step_click(context, text):
+    context.browser.find_element_by_link_text(text).click()
+
+@then('I should see "{text}"')
+def step_should_see(context, text):
+    assert text in context.browser.page_source
+
+# With data table
+@given('the following users')
+def step_users(context):
+    for row in context.table:
+        User.create(name=row['name'], email=row['email'])
+
+# With doc string
+@given('a JSON payload')
+def step_json_payload(context):
+    context.payload = json.loads(context.text)
+```
+
+## Custom Parameter Types
+
+### Ruby
+
+```ruby
+ParameterType(
+  name: 'color',
+  regexp: /red|green|blue/,
+  transformer: -> (s) { s.to_sym }
+)
+
+Given('I select the {color} option') do |color|
+  # color is a Symbol: :red, :green, or :blue
+end
+```
+
+### JavaScript
+
+```javascript
+const { defineParameterType } = require('@cucumber/cucumber');
+
+defineParameterType({
+  name: 'color',
+  regexp: /red|green|blue/,
+  transformer: s => s.toUpperCase()
+});
+
+Given('I select the {color} option', function(color) {
+  // color is "RED", "GREEN", or "BLUE"
+});
+```
+
+### Java
+
+```java
+@ParameterType("red|green|blue")
+public Color color(String color) {
+    return Color.valueOf(color.toUpperCase());
+}
+
+@Given("I select the {color} option")
+public void selectColor(Color color) {
+    // color is Color enum
+}
+```
+
+## Step Definition Organization
+
+### Ruby (features/step_definitions/)
+
+```
+features/
+├── step_definitions/
+│   ├── user_steps.rb
+│   ├── product_steps.rb
+│   └── common_steps.rb
+└── support/
+    ├── env.rb
+    └── hooks.rb
+```
+
+### JavaScript (features/step_definitions/)
+
+```
+features/
+├── step_definitions/
+│   ├── user.steps.js
+│   ├── product.steps.js
+│   └── common.steps.js
+└── support/
+    ├── world.js
+    └── hooks.js
+```
+
+### Java (src/test/java/)
+
+```
+src/test/java/com/example/
+├── steps/
+│   ├── UserSteps.java
+│   └── ProductSteps.java
+├── support/
+│   ├── Hooks.java
+│   └── SharedState.java
+└── RunCucumberTest.java
+```
+
+## Tips and Patterns
+
+### Reusable Steps
+
+Write steps that compose well:
+```gherkin
+Given I am logged in as "admin"      # reusable
+And I am on the products page        # reusable
+When I create a product named "Test" # specific
+Then I should see "Product created"  # reusable
+```
+
+### Avoid Coupling to UI
+
+Bad:
+```ruby
+When('I click the submit button') do
+  find('button[type="submit"]').click
+end
+```
+
+Good:
+```ruby
+When('I submit the form') do
+  submit_current_form  # helper that can change implementation
+end
+```
+
+### Handle Pending Steps
+
+```ruby
+Given('something not implemented yet') do
+  pending 'Waiting for API endpoint'
+end
+```
+
+```javascript
+Given('something not implemented yet', function() {
+  return 'pending';
+});
+```

--- a/plugins/ruby-rails/skills/design-patterns-ruby/SKILL.md
+++ b/plugins/ruby-rails/skills/design-patterns-ruby/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: design-patterns-ruby
+description: Comprehensive Ruby implementations of Gang of Four (GoF) design patterns. Use when implementing object-oriented design solutions, refactoring to reduce coupling, solving architecture problems, or when user mentions specific patterns (Factory, Singleton, Observer, Strategy, etc.) in Ruby context.
+---
+
+<objective>
+Provide Ruby implementations and guidance for all 23 GoF design patterns. Help agents identify which pattern solves a given problem and implement it idiomatically in Ruby.
+</objective>
+
+<quick_start>
+<pattern_selection>
+**Object Creation Problems** → Creational Patterns
+
+- Decouple creation from usage → Factory Method
+- Families of related objects → Abstract Factory
+- Complex objects with many params → Builder
+- Clone without concrete class dependency → Prototype
+- Single shared instance → Singleton
+
+**Structural Problems** → Structural Patterns
+
+- Incompatible interfaces → Adapter
+- Multiple independent dimensions → Bridge
+- Tree structures treated uniformly → Composite
+- Add behavior dynamically → Decorator
+- Simplify complex subsystems → Facade
+- Memory with many similar objects → Flyweight
+- Access control/logging/caching → Proxy
+
+**Behavioral Problems** → Behavioral Patterns
+
+- Multiple handlers in sequence → Chain of Responsibility
+- Decouple UI from business logic → Command
+- Traverse without exposing internals → Iterator
+- Reduce chaotic dependencies → Mediator
+- Undo/restore functionality → Memento
+- Notify about state changes → Observer
+- Behavior varies by state → State
+- Switch algorithms at runtime → Strategy
+- Algorithm skeleton with custom steps → Template Method
+- Operations on complex structures → Visitor
+</pattern_selection>
+
+<ruby_abstract_method>
+Ruby doesn't have built-in abstract methods. Use:
+
+```ruby
+def abstract_method
+  raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+end
+```
+
+</ruby_abstract_method>
+</quick_start>
+
+<when_to_use>
+Use this skill when encountering:
+
+- "How do I create objects without specifying exact classes?" → Factory Method/Abstract Factory
+- "Constructor has too many parameters" → Builder
+- "Need to copy objects without knowing their concrete type" → Prototype
+- "Ensure only one instance exists" → Singleton
+- "Legacy class interface doesn't match what I need" → Adapter
+- "Class explosion from combining multiple features" → Bridge
+- "Work with tree/hierarchy uniformly" → Composite
+- "Add features without modifying class" → Decorator
+- "Simplify interaction with complex library" → Facade
+- "Too many similar objects consuming memory" → Flyweight
+- "Control access/add logging to object" → Proxy
+- "Request goes through chain of handlers" → Chain of Responsibility
+- "Need undo/redo or queue operations" → Command
+- "Custom iteration over collection" → Iterator
+- "Components too tightly coupled" → Mediator
+- "Save and restore object state" → Memento
+- "Notify multiple objects of changes" → Observer
+- "Object behavior depends on state" → State
+- "Swap algorithms at runtime" → Strategy
+- "Subclasses customize algorithm steps" → Template Method
+- "Add operations to class hierarchy" → Visitor
+</when_to_use>
+
+<pattern_quick_reference>
+<creational>
+**Factory Method** - Define interface for creation, let subclasses decide type
+
+```ruby
+class Creator
+  def factory_method
+    raise NotImplementedError
+  end
+
+  def operation
+    product = factory_method
+    "Working with #{product.operation}"
+  end
+end
+
+class ConcreteCreator < Creator
+  def factory_method
+    ConcreteProduct.new
+  end
+end
+```
+
+File: `Ruby/src/factory_method/conceptual/main.rb`
+
+**Singleton** (thread-safe)
+
+```ruby
+class Singleton
+  @instance_mutex = Mutex.new
+  private_class_method :new
+
+  def self.instance
+    return @instance if @instance
+    @instance_mutex.synchronize { @instance ||= new }
+    @instance
+  end
+end
+```
+
+File: `Ruby/src/singleton/conceptual/thread_safe/main.rb`
+
+See [references/creational-patterns.md](references/creational-patterns.md) for Abstract Factory, Builder, Prototype.
+</creational>
+
+<structural>
+**Decorator** - Wrap objects to add behavior dynamically
+```ruby
+class Decorator < Component
+  def initialize(component)
+    @component = component
+  end
+
+  def operation
+    @component.operation
+  end
+end
+
+class ConcreteDecorator < Decorator
+  def operation
+    "Decorated(#{@component.operation})"
+  end
+end
+
+# Stack decorators
+
+decorated = DecoratorB.new(DecoratorA.new(ConcreteComponent.new))
+
+```
+File: `Ruby/src/decorator/conceptual/main.rb`
+
+**Adapter** - Convert interface to expected format
+```ruby
+class Adapter < Target
+  def initialize(adaptee)
+    @adaptee = adaptee
+  end
+
+  def request
+    "Adapted: #{@adaptee.specific_request}"
+  end
+end
+```
+
+File: `Ruby/src/adapter/conceptual/main.rb`
+
+See [references/structural-patterns.md](references/structural-patterns.md) for Bridge, Composite, Facade, Flyweight, Proxy.
+</structural>
+
+<behavioral>
+**Strategy** - Swap algorithms at runtime
+```ruby
+class Context
+  attr_writer :strategy
+
+  def initialize(strategy)
+    @strategy = strategy
+  end
+
+  def execute
+    @strategy.do_algorithm(data)
+  end
+end
+
+# Switch strategy at runtime
+
+context = Context.new(StrategyA.new)
+context.strategy = StrategyB.new
+
+```
+File: `Ruby/src/strategy/conceptual/main.rb`
+
+**Observer** - Notify subscribers of state changes
+```ruby
+class Subject
+  def initialize
+    @observers = []
+  end
+
+  def attach(observer)
+    @observers << observer
+  end
+
+  def detach(observer)
+    @observers.delete(observer)
+  end
+
+  def notify
+    @observers.each { |observer| observer.update(self) }
+  end
+end
+```
+
+File: `Ruby/src/observer/conceptual/main.rb`
+
+**State** - Object behavior changes based on internal state
+
+```ruby
+class Context
+  attr_accessor :state
+
+  def transition_to(state)
+    @state = state
+    @state.context = self
+  end
+
+  def request
+    @state.handle
+  end
+end
+```
+
+File: `Ruby/src/state/conceptual/main.rb`
+
+See [references/behavioral-patterns.md](references/behavioral-patterns.md) for Chain of Responsibility, Command, Iterator, Mediator, Memento, Template Method, Visitor.
+</behavioral>
+</pattern_quick_reference>
+
+<ruby_idioms>
+<deep_copy>
+For Prototype pattern, use Marshal for deep copying:
+
+```ruby
+Marshal.load(Marshal.dump(object))
+```
+
+</deep_copy>
+
+<thread_safety>
+For Singleton and shared resources, use Mutex:
+
+```ruby
+@mutex = Mutex.new
+@mutex.synchronize { @instance ||= new }
+```
+
+</thread_safety>
+
+<private_constructor>
+For Singleton pattern:
+
+```ruby
+private_class_method :new
+```
+
+</private_constructor>
+
+<accessors>
+- `attr_reader :name` - read-only
+- `attr_writer :name` - write-only
+- `attr_accessor :name` - read/write
+</accessors>
+
+<type_docs>
+Use YARD-style documentation:
+
+```ruby
+# @param [String] value
+# @return [Boolean]
+def method(value)
+end
+```
+
+</type_docs>
+</ruby_idioms>
+
+<running_examples>
+
+```bash
+ruby Ruby/src/<pattern>/conceptual/main.rb
+
+# Examples:
+ruby Ruby/src/singleton/conceptual/thread_safe/main.rb
+ruby Ruby/src/observer/conceptual/main.rb
+ruby Ruby/src/strategy/conceptual/main.rb
+ruby Ruby/src/decorator/conceptual/main.rb
+```
+
+Requires Ruby 3.2+.
+</running_examples>
+
+<detailed_references>
+
+- [references/creational-patterns.md](references/creational-patterns.md) - Factory Method, Abstract Factory, Builder, Prototype, Singleton
+- [references/structural-patterns.md](references/structural-patterns.md) - Adapter, Bridge, Composite, Decorator, Facade, Flyweight, Proxy
+- [references/behavioral-patterns.md](references/behavioral-patterns.md) - Chain of Responsibility, Command, Iterator, Mediator, Memento, Observer, State, Strategy, Template Method, Visitor
+</detailed_references>
+
+<success_criteria>
+
+- Pattern correctly solves the identified design problem
+- Ruby idioms used appropriately (NotImplementedError, Marshal, Mutex)
+- Code follows Ruby conventions (snake_case, attr_* accessors)
+- Example runs without errors via `ruby Ruby/src/<pattern>/conceptual/main.rb`
+</success_criteria>

--- a/plugins/ruby-rails/skills/design-patterns-ruby/references/behavioral-patterns.md
+++ b/plugins/ruby-rails/skills/design-patterns-ruby/references/behavioral-patterns.md
@@ -1,0 +1,858 @@
+# Behavioral Patterns Reference
+
+Detailed Ruby implementations for behavioral design patterns.
+
+## Chain of Responsibility
+
+**Intent**: Lets you pass requests along a chain of handlers. Upon receiving a request, each handler decides either to process the request or to pass it to the next handler in the chain.
+
+**When to use**:
+- Program must handle various requests whose types and sequences aren't predetermined
+- Multiple handlers must execute in a specific order
+- Handler chains need modification at runtime
+
+```ruby
+class Handler
+  attr_writer :next_handler
+
+  def next_handler=(handler)
+    @next_handler = handler
+    handler
+  end
+
+  def handle(request)
+    return @next_handler.handle(request) if @next_handler
+
+    nil
+  end
+end
+
+class MonkeyHandler < Handler
+  def handle(request)
+    if request == 'Banana'
+      "Monkey: I'll eat the #{request}"
+    elsif @next_handler
+      @next_handler.handle(request)
+    end
+  end
+end
+
+class SquirrelHandler < Handler
+  def handle(request)
+    if request == 'Nut'
+      "Squirrel: I'll eat the #{request}"
+    elsif @next_handler
+      @next_handler.handle(request)
+    end
+  end
+end
+
+class DogHandler < Handler
+  def handle(request)
+    if request == 'MeatBall'
+      "Dog: I'll eat the #{request}"
+    elsif @next_handler
+      @next_handler.handle(request)
+    end
+  end
+end
+
+# Client code
+def client_code(handler)
+  ['Nut', 'Banana', 'Cup of coffee'].each do |food|
+    puts "\nClient: Who wants a #{food}?"
+    result = handler.handle(food)
+    if result
+      print "  #{result}"
+    else
+      print "  #{food} was left untouched."
+    end
+  end
+end
+
+monkey = MonkeyHandler.new
+squirrel = SquirrelHandler.new
+dog = DogHandler.new
+
+monkey.next_handler = squirrel
+squirrel.next_handler = dog
+
+puts 'Chain: Monkey > Squirrel > Dog'
+client_code(monkey)
+puts "\n\n"
+
+puts 'Subchain: Squirrel > Dog'
+client_code(squirrel)
+```
+
+**File**: `Ruby/src/chain_of_responsibility/conceptual/main.rb`
+
+---
+
+## Command
+
+**Intent**: Turns a request into a stand-alone object that contains all information about the request. This transformation lets you pass requests as method arguments, delay or queue a request's execution, and support undoable operations.
+
+**When to use**:
+- Parameterizing objects with operations
+- Queuing, scheduling, or remote execution of operations
+- Implementing reversible operations (undo/redo)
+
+```ruby
+class Command
+  def execute
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class SimpleCommand < Command
+  def initialize(payload)
+    @payload = payload
+  end
+
+  def execute
+    puts "SimpleCommand: See, I can do simple things like printing (#{@payload})"
+  end
+end
+
+class ComplexCommand < Command
+  def initialize(receiver, a, b)
+    @receiver = receiver
+    @a = a
+    @b = b
+  end
+
+  def execute
+    print 'ComplexCommand: Complex stuff should be done by a receiver object'
+    @receiver.do_something(@a)
+    @receiver.do_something_else(@b)
+  end
+end
+
+class Receiver
+  def do_something(a)
+    print "\nReceiver: Working on (#{a}.)"
+  end
+
+  def do_something_else(b)
+    print "\nReceiver: Also working on (#{b}.)"
+  end
+end
+
+class Invoker
+  def on_start=(command)
+    @on_start = command
+  end
+
+  def on_finish=(command)
+    @on_finish = command
+  end
+
+  def do_something_important
+    puts 'Invoker: Does anybody want something done before I begin?'
+    @on_start.execute if @on_start.is_a? Command
+
+    puts 'Invoker: ...doing something really important...'
+
+    puts 'Invoker: Does anybody want something done after I finish?'
+    @on_finish.execute if @on_finish.is_a? Command
+  end
+end
+
+# Client code
+invoker = Invoker.new
+invoker.on_start = SimpleCommand.new('Say Hi!')
+receiver = Receiver.new
+invoker.on_finish = ComplexCommand.new(receiver, 'Send email', 'Save report')
+
+invoker.do_something_important
+```
+
+**File**: `Ruby/src/command/conceptual/main.rb`
+
+---
+
+## Iterator
+
+**Intent**: Lets you traverse elements of a collection without exposing its underlying representation (list, stack, tree, etc.).
+
+**When to use**:
+- Collection has intricate internal structure requiring simplified access
+- Multiple algorithms for traversing collections create redundant code
+- Code must handle various collection types or unknown future structures
+
+**Ruby note**: Ruby's `Enumerable` module provides built-in iterator support via `each`.
+
+```ruby
+class AlphabeticalOrderIterator
+  include Enumerable
+
+  attr_accessor :reverse
+  private :reverse
+
+  attr_accessor :collection
+  private :collection
+
+  def initialize(collection, reverse: false)
+    @collection = collection
+    @reverse = reverse
+  end
+
+  def each(&block)
+    return @collection.items.reverse.each(&block) if reverse
+
+    @collection.items.each(&block)
+  end
+end
+
+class WordsCollection
+  attr_accessor :items
+
+  def initialize(collection = [])
+    @items = collection
+  end
+
+  def iterator
+    AlphabeticalOrderIterator.new(self)
+  end
+
+  def reverse_iterator
+    AlphabeticalOrderIterator.new(self, reverse: true)
+  end
+end
+
+# Client code
+collection = WordsCollection.new
+collection.items << 'First'
+collection.items << 'Second'
+collection.items << 'Third'
+
+puts 'Straight traversal:'
+collection.iterator.each { |item| puts item }
+puts "\n\n"
+
+puts 'Reverse traversal:'
+collection.reverse_iterator.each { |item| puts item }
+```
+
+**File**: `Ruby/src/iterator/conceptual/main.rb`
+
+---
+
+## Mediator
+
+**Intent**: Lets you reduce chaotic dependencies between objects. The pattern restricts direct communications between the objects and forces them to collaborate only via a mediator object.
+
+**When to use**:
+- Classes are tightly coupled to many other classes
+- Components cannot be reused because they depend on too many others
+- Creating excessive component subclasses to reuse basic behavior
+
+```ruby
+class Mediator
+  def notify(_sender, _event)
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class ConcreteMediator < Mediator
+  def initialize(component1, component2)
+    @component1 = component1
+    @component1.mediator = self
+    @component2 = component2
+    @component2.mediator = self
+  end
+
+  def notify(_sender, event)
+    if event == 'A'
+      puts 'Mediator reacts on A and triggers following operations:'
+      @component2.do_c
+    elsif event == 'D'
+      puts 'Mediator reacts on D and triggers following operations:'
+      @component1.do_b
+      @component2.do_c
+    end
+  end
+end
+
+class BaseComponent
+  attr_accessor :mediator
+
+  def initialize(mediator = nil)
+    @mediator = mediator
+  end
+end
+
+class Component1 < BaseComponent
+  def do_a
+    puts 'Component 1 does A.'
+    @mediator.notify(self, 'A')
+  end
+
+  def do_b
+    puts 'Component 1 does B.'
+    @mediator.notify(self, 'B')
+  end
+end
+
+class Component2 < BaseComponent
+  def do_c
+    puts 'Component 2 does C.'
+    @mediator.notify(self, 'C')
+  end
+
+  def do_d
+    puts 'Component 2 does D.'
+    @mediator.notify(self, 'D')
+  end
+end
+
+# Client code
+c1 = Component1.new
+c2 = Component2.new
+ConcreteMediator.new(c1, c2)
+
+puts 'Client triggers operation A.'
+c1.do_a
+
+puts "\n"
+
+puts 'Client triggers operation D.'
+c2.do_d
+```
+
+**File**: `Ruby/src/mediator/conceptual/main.rb`
+
+---
+
+## Memento
+
+**Intent**: Lets you save and restore the previous state of an object without revealing the details of its implementation.
+
+**When to use**:
+- Need snapshots of object state to restore previous states (undo/redo, transactions)
+- Direct access to object fields/getters/setters violates encapsulation
+
+```ruby
+class Originator
+  attr_accessor :state
+  private :state
+
+  def initialize(state)
+    @state = state
+    puts "Originator: My initial state is: #{@state}"
+  end
+
+  def do_something
+    puts 'Originator: I\'m doing something important.'
+    @state = generate_random_string(30)
+    puts "Originator: and my state has changed to: #{@state}"
+  end
+
+  private def generate_random_string(length = 10)
+    ascii_letters = [*'a'..'z', *'A'..'Z']
+    (0...length).map { ascii_letters.sample }.join
+  end
+
+  def save
+    ConcreteMemento.new(@state)
+  end
+
+  def restore(memento)
+    @state = memento.state
+    puts "Originator: My state has changed to: #{@state}"
+  end
+end
+
+class Memento
+  def state
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def name
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def date
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class ConcreteMemento < Memento
+  def initialize(state)
+    @state = state
+    @date = Time.now.strftime('%F %T')
+  end
+
+  attr_reader :state
+
+  def name
+    "#{@date} / (#{@state[0, 9]}...)"
+  end
+
+  attr_reader :date
+end
+
+class Caretaker
+  def initialize(originator)
+    @mementos = []
+    @originator = originator
+  end
+
+  def backup
+    puts "\nCaretaker: Saving Originator's state..."
+    @mementos << @originator.save
+  end
+
+  def undo
+    return if @mementos.empty?
+
+    memento = @mementos.pop
+    puts "Caretaker: Restoring state to: #{memento.name}"
+
+    begin
+      @originator.restore(memento)
+    rescue StandardError
+      undo
+    end
+  end
+
+  def show_history
+    puts 'Caretaker: Here\'s the list of mementos:'
+
+    @mementos.each { |memento| puts memento.name }
+  end
+end
+
+# Client code
+originator = Originator.new('Super-duper-super-puper-super.')
+caretaker = Caretaker.new(originator)
+
+caretaker.backup
+originator.do_something
+
+caretaker.backup
+originator.do_something
+
+caretaker.backup
+originator.do_something
+
+puts "\n"
+caretaker.show_history
+
+puts "\nClient: Now, let's rollback!\n\n"
+caretaker.undo
+
+puts "\nClient: Once more!\n\n"
+caretaker.undo
+```
+
+**File**: `Ruby/src/memento/conceptual/main.rb`
+
+---
+
+## Observer
+
+**Intent**: Lets you define a subscription mechanism to notify multiple objects about any events that happen to the object they're observing.
+
+**When to use**:
+- Changes to one object's state may require updating other objects, and the set is unknown or dynamic
+- Some objects must observe others temporarily or in specific cases
+- Building event-driven systems or pub/sub mechanisms
+
+```ruby
+class Subject
+  def attach(observer)
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def detach(observer)
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def notify
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class ConcreteSubject < Subject
+  attr_accessor :state
+
+  def initialize
+    @observers = []
+  end
+
+  def attach(observer)
+    puts 'Subject: Attached an observer.'
+    @observers << observer
+  end
+
+  def detach(observer)
+    @observers.delete(observer)
+  end
+
+  def notify
+    puts 'Subject: Notifying observers...'
+    @observers.each { |observer| observer.update(self) }
+  end
+
+  def some_business_logic
+    puts "\nSubject: I'm doing something important."
+    @state = rand(0..10)
+    puts "Subject: My state has just changed to: #{@state}"
+    notify
+  end
+end
+
+class Observer
+  def update(_subject)
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class ConcreteObserverA < Observer
+  def update(subject)
+    puts 'ConcreteObserverA: Reacted to the event' if subject.state < 3
+  end
+end
+
+class ConcreteObserverB < Observer
+  def update(subject)
+    puts 'ConcreteObserverB: Reacted to the event' if subject.state.zero? || subject.state >= 2
+  end
+end
+
+# Client code
+subject = ConcreteSubject.new
+
+observer_a = ConcreteObserverA.new
+subject.attach(observer_a)
+
+observer_b = ConcreteObserverB.new
+subject.attach(observer_b)
+
+subject.some_business_logic
+subject.some_business_logic
+
+subject.detach(observer_a)
+
+subject.some_business_logic
+```
+
+**File**: `Ruby/src/observer/conceptual/main.rb`
+
+---
+
+## State
+
+**Intent**: Lets an object alter its behavior when its internal state changes. It appears as if the object changed its class.
+
+**When to use**:
+- Object behaves differently depending on current state and has many states
+- Class contains massive conditionals controlling behavior based on field values
+- Lots of duplicate code across similar states and transitions
+
+```ruby
+class Context
+  attr_accessor :state
+
+  def initialize(state)
+    transition_to(state)
+  end
+
+  def transition_to(state)
+    puts "Context: Transition to #{state.class}."
+    @state = state
+    @state.context = self
+  end
+
+  def request1
+    @state.handle1
+  end
+
+  def request2
+    @state.handle2
+  end
+end
+
+class State
+  attr_accessor :context
+
+  def handle1
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def handle2
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class ConcreteStateA < State
+  def handle1
+    puts 'ConcreteStateA handles request1.'
+    puts 'ConcreteStateA wants to change the state of the context.'
+    @context.transition_to(ConcreteStateB.new)
+  end
+
+  def handle2
+    puts 'ConcreteStateA handles request2.'
+  end
+end
+
+class ConcreteStateB < State
+  def handle1
+    puts 'ConcreteStateB handles request1.'
+  end
+
+  def handle2
+    puts 'ConcreteStateB handles request2.'
+    puts 'ConcreteStateB wants to change the state of the context.'
+    @context.transition_to(ConcreteStateA.new)
+  end
+end
+
+# Client code
+context = Context.new(ConcreteStateA.new)
+context.request1
+context.request2
+```
+
+**File**: `Ruby/src/state/conceptual/main.rb`
+
+---
+
+## Strategy
+
+**Intent**: Lets you define a family of algorithms, put each of them into a separate class, and make their objects interchangeable.
+
+**When to use**:
+- Want to use different algorithm variants and switch between them at runtime
+- Similar classes differ only in their behavior
+- Need to isolate algorithm implementation details from business logic
+- Eliminating massive conditionals that select algorithm implementations
+
+```ruby
+class Context
+  attr_writer :strategy
+
+  def initialize(strategy)
+    @strategy = strategy
+  end
+
+  def strategy=(strategy)
+    @strategy = strategy
+  end
+
+  def do_some_business_logic
+    puts 'Context: Sorting data using the strategy (not sure how it\'ll do it)'
+    result = @strategy.do_algorithm(%w[a b c d e])
+    print result.join(',')
+  end
+end
+
+class Strategy
+  def do_algorithm(_data)
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class ConcreteStrategyA < Strategy
+  def do_algorithm(data)
+    data.sort
+  end
+end
+
+class ConcreteStrategyB < Strategy
+  def do_algorithm(data)
+    data.sort.reverse
+  end
+end
+
+# Client code
+context = Context.new(ConcreteStrategyA.new)
+puts 'Client: Strategy is set to normal sorting.'
+context.do_some_business_logic
+puts "\n\n"
+
+puts 'Client: Strategy is set to reverse sorting.'
+context.strategy = ConcreteStrategyB.new
+context.do_some_business_logic
+```
+
+**File**: `Ruby/src/strategy/conceptual/main.rb`
+
+---
+
+## Template Method
+
+**Intent**: Defines the skeleton of an algorithm in the superclass but lets subclasses override specific steps of the algorithm without changing its structure.
+
+**When to use**:
+- Let clients extend only particular algorithm steps, not the entire algorithm
+- Consolidating nearly identical algorithms with minor differences
+- Eliminating code duplication by pulling common steps into base class
+
+```ruby
+class AbstractClass
+  def template_method
+    base_operation1
+    required_operations1
+    base_operation2
+    hook1
+    required_operations2
+    base_operation3
+    hook2
+  end
+
+  def base_operation1
+    puts 'AbstractClass says: I am doing the bulk of the work'
+  end
+
+  def base_operation2
+    puts 'AbstractClass says: But I let subclasses override some operations'
+  end
+
+  def base_operation3
+    puts 'AbstractClass says: But I am doing the bulk of the work anyway'
+  end
+
+  def required_operations1
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def required_operations2
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def hook1; end
+
+  def hook2; end
+end
+
+class ConcreteClass1 < AbstractClass
+  def required_operations1
+    puts 'ConcreteClass1 says: Implemented Operation1'
+  end
+
+  def required_operations2
+    puts 'ConcreteClass1 says: Implemented Operation2'
+  end
+end
+
+class ConcreteClass2 < AbstractClass
+  def required_operations1
+    puts 'ConcreteClass2 says: Implemented Operation1'
+  end
+
+  def required_operations2
+    puts 'ConcreteClass2 says: Implemented Operation2'
+  end
+
+  def hook1
+    puts 'ConcreteClass2 says: Overridden Hook1'
+  end
+end
+
+# Client code
+def client_code(abstract_class)
+  abstract_class.template_method
+end
+
+puts 'Same client code can work with different subclasses:'
+client_code(ConcreteClass1.new)
+puts "\n"
+
+puts 'Same client code can work with different subclasses:'
+client_code(ConcreteClass2.new)
+```
+
+**File**: `Ruby/src/template_method/conceptual/main.rb`
+
+---
+
+## Visitor
+
+**Intent**: Lets you separate algorithms from the objects on which they operate.
+
+**When to use**:
+- Need to perform operations on complex structures with different class types
+- Extract auxiliary behaviors from domain objects to keep them focused
+- Add behaviors that apply inconsistently across hierarchies
+- Anticipate multiple future operations on stable object structures
+
+```ruby
+class Component
+  def accept(_visitor)
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class ConcreteComponentA < Component
+  def accept(visitor)
+    visitor.visit_concrete_component_a(self)
+  end
+
+  def exclusive_method_of_concrete_component_a
+    'A'
+  end
+end
+
+class ConcreteComponentB < Component
+  def accept(visitor)
+    visitor.visit_concrete_component_b(self)
+  end
+
+  def special_method_of_concrete_component_b
+    'B'
+  end
+end
+
+class Visitor
+  def visit_concrete_component_a(_element)
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def visit_concrete_component_b(_element)
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class ConcreteVisitor1 < Visitor
+  def visit_concrete_component_a(element)
+    puts "#{element.exclusive_method_of_concrete_component_a} + ConcreteVisitor1"
+  end
+
+  def visit_concrete_component_b(element)
+    puts "#{element.special_method_of_concrete_component_b} + ConcreteVisitor1"
+  end
+end
+
+class ConcreteVisitor2 < Visitor
+  def visit_concrete_component_a(element)
+    puts "#{element.exclusive_method_of_concrete_component_a} + ConcreteVisitor2"
+  end
+
+  def visit_concrete_component_b(element)
+    puts "#{element.special_method_of_concrete_component_b} + ConcreteVisitor2"
+  end
+end
+
+# Client code
+def client_code(components, visitor)
+  components.each do |component|
+    component.accept(visitor)
+  end
+end
+
+components = [ConcreteComponentA.new, ConcreteComponentB.new]
+
+puts 'The client code works with all visitors via the base Visitor interface:'
+visitor1 = ConcreteVisitor1.new
+client_code(components, visitor1)
+
+puts 'It allows the same client code to work with different types of visitors:'
+visitor2 = ConcreteVisitor2.new
+client_code(components, visitor2)
+```
+
+**File**: `Ruby/src/visitor/conceptual/main.rb`

--- a/plugins/ruby-rails/skills/design-patterns-ruby/references/creational-patterns.md
+++ b/plugins/ruby-rails/skills/design-patterns-ruby/references/creational-patterns.md
@@ -1,0 +1,411 @@
+# Creational Patterns Reference
+
+Detailed Ruby implementations for creational design patterns.
+
+## Factory Method
+
+**Intent**: Provides an interface for creating objects in a superclass, but allows subclasses to alter the type of objects that will be created.
+
+**When to use**:
+- Cannot predict exact object types your code requires beforehand
+- Want library/framework users to extend components through inheritance
+- Need to reuse expensive objects through pooling
+
+```ruby
+class Creator
+  def factory_method
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def some_operation
+    product = factory_method
+    "Creator: The same creator's code has just worked with #{product.operation}"
+  end
+end
+
+class ConcreteCreator1 < Creator
+  def factory_method
+    ConcreteProduct1.new
+  end
+end
+
+class ConcreteCreator2 < Creator
+  def factory_method
+    ConcreteProduct2.new
+  end
+end
+
+class Product
+  def operation
+    raise NotImplementedError
+  end
+end
+
+class ConcreteProduct1 < Product
+  def operation
+    '{Result of the ConcreteProduct1}'
+  end
+end
+
+class ConcreteProduct2 < Product
+  def operation
+    '{Result of the ConcreteProduct2}'
+  end
+end
+
+# Client code
+def client_code(creator)
+  print "Client: I'm not aware of the creator's class, but it still works.\n"\
+        "#{creator.some_operation}"
+end
+
+client_code(ConcreteCreator1.new)
+client_code(ConcreteCreator2.new)
+```
+
+**File**: `Ruby/src/factory_method/conceptual/main.rb`
+
+---
+
+## Abstract Factory
+
+**Intent**: Lets you produce families of related objects without specifying their concrete classes.
+
+**When to use**:
+- Code must work with various product families without depending on concrete classes
+- Want to allow future extensibility for new product variants
+- A class with multiple Factory Methods is becoming unwieldy
+
+```ruby
+class AbstractFactory
+  def create_product_a
+    raise NotImplementedError
+  end
+
+  def create_product_b
+    raise NotImplementedError
+  end
+end
+
+class ConcreteFactory1 < AbstractFactory
+  def create_product_a
+    ConcreteProductA1.new
+  end
+
+  def create_product_b
+    ConcreteProductB1.new
+  end
+end
+
+class ConcreteFactory2 < AbstractFactory
+  def create_product_a
+    ConcreteProductA2.new
+  end
+
+  def create_product_b
+    ConcreteProductB2.new
+  end
+end
+
+class AbstractProductA
+  def useful_function_a
+    raise NotImplementedError
+  end
+end
+
+class ConcreteProductA1 < AbstractProductA
+  def useful_function_a
+    'The result of the product A1.'
+  end
+end
+
+class ConcreteProductA2 < AbstractProductA
+  def useful_function_a
+    'The result of the product A2.'
+  end
+end
+
+class AbstractProductB
+  def useful_function_b
+    raise NotImplementedError
+  end
+
+  def another_useful_function_b(collaborator)
+    raise NotImplementedError
+  end
+end
+
+class ConcreteProductB1 < AbstractProductB
+  def useful_function_b
+    'The result of the product B1.'
+  end
+
+  def another_useful_function_b(collaborator)
+    result = collaborator.useful_function_a
+    "The result of the B1 collaborating with the (#{result})"
+  end
+end
+
+# Client code
+def client_code(factory)
+  product_a = factory.create_product_a
+  product_b = factory.create_product_b
+  puts product_b.useful_function_b
+  puts product_b.another_useful_function_b(product_a)
+end
+
+client_code(ConcreteFactory1.new)
+client_code(ConcreteFactory2.new)
+```
+
+**File**: `Ruby/src/abstract_factory/conceptual/main.rb`
+
+---
+
+## Builder
+
+**Intent**: Lets you construct complex objects step by step. Allows producing different types and representations using the same construction code.
+
+**When to use**:
+- Eliminating telescoping constructors (constructors with many optional parameters)
+- Creating different representations of a product using similar construction steps
+- Building complex composite structures like trees
+
+```ruby
+class Builder
+  def produce_part_a
+    raise NotImplementedError
+  end
+
+  def produce_part_b
+    raise NotImplementedError
+  end
+
+  def produce_part_c
+    raise NotImplementedError
+  end
+end
+
+class ConcreteBuilder1 < Builder
+  def initialize
+    reset
+  end
+
+  def reset
+    @product = Product1.new
+  end
+
+  def product
+    product = @product
+    reset
+    product
+  end
+
+  def produce_part_a
+    @product.add('PartA1')
+  end
+
+  def produce_part_b
+    @product.add('PartB1')
+  end
+
+  def produce_part_c
+    @product.add('PartC1')
+  end
+end
+
+class Product1
+  def initialize
+    @parts = []
+  end
+
+  def add(part)
+    @parts << part
+  end
+
+  def list_parts
+    "Product parts: #{@parts.join(', ')}"
+  end
+end
+
+class Director
+  attr_accessor :builder
+
+  def initialize
+    @builder = nil
+  end
+
+  def builder=(builder)
+    @builder = builder
+  end
+
+  def build_minimal_viable_product
+    @builder.produce_part_a
+  end
+
+  def build_full_featured_product
+    @builder.produce_part_a
+    @builder.produce_part_b
+    @builder.produce_part_c
+  end
+end
+
+# Client code
+director = Director.new
+builder = ConcreteBuilder1.new
+director.builder = builder
+
+puts 'Standard basic product:'
+director.build_minimal_viable_product
+puts builder.product.list_parts
+
+puts 'Standard full featured product:'
+director.build_full_featured_product
+puts builder.product.list_parts
+
+# Custom product without Director
+puts 'Custom product:'
+builder.produce_part_a
+builder.produce_part_b
+puts builder.product.list_parts
+```
+
+**File**: `Ruby/src/builder/conceptual/main.rb`
+
+---
+
+## Prototype
+
+**Intent**: Lets you copy existing objects without making your code dependent on their classes.
+
+**When to use**:
+- Code receives objects from third-party sources through interfaces only and needs to copy them
+- Reducing subclass proliferation when you have complex classes requiring repeated configuration
+
+**Ruby note**: Use `Marshal.load(Marshal.dump(object))` for deep copying.
+
+```ruby
+class Prototype
+  attr_accessor :primitive, :component, :circular_reference
+
+  def clone
+    @component = deep_copy(@component)
+    @circular_reference = deep_copy(@circular_reference)
+    @circular_reference.prototype = self
+    deep_copy(self)
+  end
+
+  private
+
+  def deep_copy(object)
+    Marshal.load(Marshal.dump(object))
+  end
+end
+
+class ComponentWithBackReference
+  attr_accessor :prototype
+
+  def initialize(prototype)
+    @prototype = prototype
+  end
+end
+
+# Client code
+p1 = Prototype.new
+p1.primitive = 245
+p1.component = Time.now
+p1.circular_reference = ComponentWithBackReference.new(p1)
+
+p2 = p1.clone
+
+if p1.primitive == p2.primitive
+  puts 'Primitive field values have been carried over to a clone.'
+else
+  puts 'Primitive field values have not been copied.'
+end
+
+if p1.component.equal?(p2.component)
+  puts 'Simple component has not been cloned.'
+else
+  puts 'Simple component has been cloned.'
+end
+
+if p1.circular_reference.equal?(p2.circular_reference)
+  puts 'Component with back reference has not been cloned.'
+else
+  puts 'Component with back reference has been cloned.'
+end
+
+if p1.circular_reference.prototype.equal?(p2.circular_reference.prototype)
+  puts 'Component with back reference is linked to original object.'
+else
+  puts 'Component with back reference is linked to the clone.'
+end
+```
+
+**File**: `Ruby/src/prototype/conceptual/main.rb`
+
+---
+
+## Singleton
+
+**Intent**: Lets you ensure that a class has only one instance, while providing a global access point to this instance.
+
+**When to use**:
+- Program requires exactly one shared instance accessible across components (database connection, logger)
+- Need stricter control over global state than traditional global variables
+- Want to restrict object creation
+
+### Thread-Safe Implementation
+
+```ruby
+class Singleton
+  attr_reader :value
+
+  @instance_mutex = Mutex.new
+
+  private_class_method :new
+
+  def initialize(value)
+    @value = value
+  end
+
+  def self.instance(value)
+    return @instance if @instance
+
+    @instance_mutex.synchronize do
+      @instance ||= new(value)
+    end
+
+    @instance
+  end
+
+  def some_business_logic
+    # ...
+  end
+end
+
+# Test thread safety
+def test_singleton(value)
+  singleton = Singleton.instance(value)
+  puts singleton.value
+end
+
+puts "If you see the same value, then singleton was reused (yay!)\n"\
+     "If you see different values, then 2 singletons were created (booo!!)\n\n"\
+     "RESULT:\n\n"
+
+process1 = Thread.new { test_singleton('FOO') }
+process2 = Thread.new { test_singleton('BAR') }
+process1.join
+process2.join
+```
+
+**Key Ruby techniques**:
+- `private_class_method :new` - prevents direct instantiation
+- `Mutex` for thread safety
+- Double-checked locking pattern
+
+**Files**:
+- Thread-safe: `Ruby/src/singleton/conceptual/thread_safe/main.rb`
+- Non-thread-safe: `Ruby/src/singleton/conceptual/non_thread_safe/main.rb`

--- a/plugins/ruby-rails/skills/design-patterns-ruby/references/structural-patterns.md
+++ b/plugins/ruby-rails/skills/design-patterns-ruby/references/structural-patterns.md
@@ -1,0 +1,505 @@
+# Structural Patterns Reference
+
+Detailed Ruby implementations for structural design patterns.
+
+## Adapter
+
+**Intent**: Allows objects with incompatible interfaces to collaborate.
+
+**When to use**:
+- Existing class interface isn't compatible with your code
+- Integrating third-party, legacy, or dependency-heavy classes you cannot modify
+- Multiple subclasses lack common methods and you want to avoid code duplication
+
+```ruby
+class Target
+  def request
+    "Target: The default target's behavior."
+  end
+end
+
+class Adaptee
+  def specific_request
+    '.eetpadA eht fo roivaheb laicepS'
+  end
+end
+
+class Adapter < Target
+  def initialize(adaptee)
+    @adaptee = adaptee
+  end
+
+  def request
+    "Adapter: (TRANSLATED) #{@adaptee.specific_request.reverse}"
+  end
+end
+
+# Client code
+def client_code(target)
+  print target.request
+end
+
+puts 'Client: I can work just fine with the Target objects:'
+target = Target.new
+client_code(target)
+puts "\n\n"
+
+adaptee = Adaptee.new
+puts "Client: The Adaptee class has a weird interface. See, I don't understand it:"
+puts "Adaptee: #{adaptee.specific_request}"
+puts "\n"
+
+puts 'Client: But I can work with it via the Adapter:'
+adapter = Adapter.new(adaptee)
+client_code(adapter)
+```
+
+**Files**:
+- Conceptual: `Ruby/src/adapter/conceptual/main.rb`
+- Real World (speed conversion): `Ruby/src/adapter/real_world/main.rb`
+
+---
+
+## Bridge
+
+**Intent**: Lets you split a large class or a set of closely related classes into two separate hierarchies—abstraction and implementation—which can be developed independently.
+
+**When to use**:
+- Have a monolithic class with multiple functionality variants (e.g., database server support)
+- Need to extend a class in independent orthogonal dimensions
+- Need to switch implementations at runtime
+
+```ruby
+class Abstraction
+  def initialize(implementation)
+    @implementation = implementation
+  end
+
+  def operation
+    "Abstraction: Base operation with:\n"\
+    "#{@implementation.operation_implementation}"
+  end
+end
+
+class ExtendedAbstraction < Abstraction
+  def operation
+    "ExtendedAbstraction: Extended operation with:\n"\
+    "#{@implementation.operation_implementation}"
+  end
+end
+
+class Implementation
+  def operation_implementation
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class ConcreteImplementationA < Implementation
+  def operation_implementation
+    'ConcreteImplementationA: Here\'s the result on the platform A.'
+  end
+end
+
+class ConcreteImplementationB < Implementation
+  def operation_implementation
+    'ConcreteImplementationB: Here\'s the result on the platform B.'
+  end
+end
+
+# Client code
+def client_code(abstraction)
+  print abstraction.operation
+end
+
+implementation = ConcreteImplementationA.new
+abstraction = Abstraction.new(implementation)
+client_code(abstraction)
+puts "\n\n"
+
+implementation = ConcreteImplementationB.new
+abstraction = ExtendedAbstraction.new(implementation)
+client_code(abstraction)
+```
+
+**File**: `Ruby/src/bridge/conceptual/main.rb`
+
+---
+
+## Composite
+
+**Intent**: Lets you compose objects into tree structures and then work with these structures as if they were individual objects.
+
+**When to use**:
+- Core model fits a tree structure of simple elements and containers
+- Client code should treat individual objects and compositions uniformly
+- Need recursive operations over hierarchical structures
+
+```ruby
+class Component
+  def parent
+    @parent
+  end
+
+  def parent=(parent)
+    @parent = parent
+  end
+
+  def add(component)
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def remove(component)
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+
+  def composite?
+    false
+  end
+
+  def operation
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class Leaf < Component
+  def operation
+    'Leaf'
+  end
+end
+
+class Composite < Component
+  def initialize
+    @children = []
+  end
+
+  def add(component)
+    @children << component
+    component.parent = self
+  end
+
+  def remove(component)
+    @children.delete(component)
+    component.parent = nil
+  end
+
+  def composite?
+    true
+  end
+
+  def operation
+    results = []
+    @children.each { |child| results << child.operation }
+    "Branch(#{results.join('+')})"
+  end
+end
+
+# Client code
+def client_code(component)
+  puts "RESULT: #{component.operation}"
+end
+
+def client_code2(component1, component2)
+  component1.add(component2) if component1.composite?
+  print "RESULT: #{component1.operation}"
+end
+
+simple = Leaf.new
+puts 'Client: I\'ve got a simple component:'
+client_code(simple)
+puts "\n"
+
+tree = Composite.new
+branch1 = Composite.new
+branch1.add(Leaf.new)
+branch1.add(Leaf.new)
+branch2 = Composite.new
+branch2.add(Leaf.new)
+tree.add(branch1)
+tree.add(branch2)
+puts 'Client: Now I\'ve got a composite tree:'
+client_code(tree)
+puts "\n"
+
+puts 'Client: I don\'t need to check component classes even when managing the tree:'
+client_code2(tree, simple)
+```
+
+**File**: `Ruby/src/composite/conceptual/main.rb`
+
+---
+
+## Decorator
+
+**Intent**: Lets you attach new behaviors to objects by placing these objects inside special wrapper objects that contain the behaviors.
+
+**When to use**:
+- Need to assign extra behaviors at runtime without modifying code that uses the objects
+- Extending behavior when inheritance is problematic (final classes, excessive subclasses)
+- Combining multiple behaviors flexibly
+
+```ruby
+class Component
+  def operation
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class ConcreteComponent < Component
+  def operation
+    'ConcreteComponent'
+  end
+end
+
+class Decorator < Component
+  attr_accessor :component
+
+  def initialize(component)
+    @component = component
+  end
+
+  def operation
+    @component.operation
+  end
+end
+
+class ConcreteDecoratorA < Decorator
+  def operation
+    "ConcreteDecoratorA(#{@component.operation})"
+  end
+end
+
+class ConcreteDecoratorB < Decorator
+  def operation
+    "ConcreteDecoratorB(#{@component.operation})"
+  end
+end
+
+# Client code
+def client_code(component)
+  print "RESULT: #{component.operation}"
+end
+
+simple = ConcreteComponent.new
+puts 'Client: I\'ve got a simple component:'
+client_code(simple)
+puts "\n\n"
+
+# Decorators can wrap not only simple components but other decorators as well
+decorator1 = ConcreteDecoratorA.new(simple)
+decorator2 = ConcreteDecoratorB.new(decorator1)
+puts 'Client: Now I\'ve got a decorated component:'
+client_code(decorator2)
+```
+
+**File**: `Ruby/src/decorator/conceptual/main.rb`
+
+---
+
+## Facade
+
+**Intent**: Provides a simplified interface to a library, a framework, or any other complex set of classes.
+
+**When to use**:
+- Need to offer basic access to a complex subsystem
+- Subsystems are becoming more sophisticated and require increased configuration
+- Structuring subsystems in layers with controlled communication
+
+```ruby
+class Facade
+  def initialize(subsystem1, subsystem2)
+    @subsystem1 = subsystem1 || Subsystem1.new
+    @subsystem2 = subsystem2 || Subsystem2.new
+  end
+
+  def operation
+    results = []
+    results << 'Facade initializes subsystems:'
+    results << @subsystem1.operation1
+    results << @subsystem2.operation1
+    results << 'Facade orders subsystems to perform the action:'
+    results << @subsystem1.operation_n
+    results << @subsystem2.operation_z
+    results.join("\n")
+  end
+end
+
+class Subsystem1
+  def operation1
+    'Subsystem1: Ready!'
+  end
+
+  def operation_n
+    'Subsystem1: Go!'
+  end
+end
+
+class Subsystem2
+  def operation1
+    'Subsystem2: Get ready!'
+  end
+
+  def operation_z
+    'Subsystem2: Fire!'
+  end
+end
+
+# Client code
+def client_code(facade)
+  print facade.operation
+end
+
+subsystem1 = Subsystem1.new
+subsystem2 = Subsystem2.new
+facade = Facade.new(subsystem1, subsystem2)
+client_code(facade)
+```
+
+**File**: `Ruby/src/facade/conceptual/main.rb`
+
+---
+
+## Flyweight
+
+**Intent**: Lets you fit more objects into the available amount of RAM by sharing common parts of state between multiple objects instead of keeping all of the data in each object.
+
+**When to use**:
+- Program must support huge numbers of objects that barely fit in RAM
+- Many objects contain duplicate state that can be extracted and shared
+- Memory optimization is critical
+
+```ruby
+class Flyweight
+  def initialize(shared_state)
+    @shared_state = shared_state
+  end
+
+  def operation(unique_state)
+    s = @shared_state.to_json
+    u = unique_state.to_json
+    print "Flyweight: Displaying shared (#{s}) and unique (#{u}) state."
+  end
+end
+
+class FlyweightFactory
+  def initialize(initial_flyweights)
+    @flyweights = {}
+    initial_flyweights.each do |state|
+      @flyweights[get_key(state)] = Flyweight.new(state)
+    end
+  end
+
+  def get_key(state)
+    state.sort.join('_')
+  end
+
+  def get_flyweight(shared_state)
+    key = get_key(shared_state)
+
+    if @flyweights.key?(key)
+      puts 'FlyweightFactory: Reusing existing flyweight.'
+    else
+      puts 'FlyweightFactory: Can\'t find a flyweight, creating new one.'
+      @flyweights[key] = Flyweight.new(shared_state)
+    end
+
+    @flyweights[key]
+  end
+
+  def list_flyweights
+    count = @flyweights.size
+    puts "FlyweightFactory: I have #{count} flyweights:"
+    print @flyweights.keys.join("\n")
+  end
+end
+
+# Client code
+def add_car_to_police_database(factory, plates, owner, brand, model, color)
+  puts "\n\nClient: Adding a car to database."
+  flyweight = factory.get_flyweight([brand, model, color])
+  flyweight.operation([plates, owner])
+end
+
+factory = FlyweightFactory.new([
+  %w[Chevrolet Camaro2018 pink],
+  %w[Mercedes C300 black],
+  %w[Mercedes C500 red],
+  %w[BMW M5 red],
+  %w[BMW X6 white]
+])
+
+factory.list_flyweights
+
+add_car_to_police_database(factory, 'CL234IR', 'James Doe', 'BMW', 'M5', 'red')
+add_car_to_police_database(factory, 'CL234IR', 'James Doe', 'BMW', 'X1', 'red')
+
+puts "\n\n"
+factory.list_flyweights
+```
+
+**File**: `Ruby/src/flyweight/conceptual/main.rb`
+
+---
+
+## Proxy
+
+**Intent**: Lets you provide a substitute or placeholder for another object. A proxy controls access to the original object, allowing you to perform something either before or after the request gets through to the original object.
+
+**When to use**:
+- Lazy initialization - delay creating resource-intensive objects
+- Access control - restrict which clients can use specific services
+- Remote services - handle network communication transparently
+- Logging/caching - maintain request histories or cache results
+- Smart references - manage object lifecycles
+
+```ruby
+class Subject
+  def request
+    raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+  end
+end
+
+class RealSubject < Subject
+  def request
+    puts 'RealSubject: Handling request.'
+  end
+end
+
+class Proxy < Subject
+  def initialize(real_subject)
+    @real_subject = real_subject
+  end
+
+  def request
+    return unless check_access
+
+    @real_subject.request
+    log_access
+  end
+
+  def check_access
+    puts 'Proxy: Checking access prior to firing a real request.'
+    true
+  end
+
+  def log_access
+    print 'Proxy: Logging the time of request.'
+  end
+end
+
+# Client code
+def client_code(subject)
+  subject.request
+end
+
+puts 'Client: Executing the client code with a real subject:'
+real_subject = RealSubject.new
+client_code(real_subject)
+
+puts "\n"
+
+puts 'Client: Executing the same client code with a proxy:'
+proxy = Proxy.new(real_subject)
+client_code(proxy)
+```
+
+**File**: `Ruby/src/proxy/conceptual/main.rb`


### PR DESCRIPTION
## Summary

- Adds **cucumber-gherkin** skill for BDD testing with Cucumber and Gherkin syntax, covering feature files, step definitions (Ruby/JS/Java/Python), hooks, tags, and best practices
- Adds **design-patterns-ruby** skill with all 23 GoF design patterns implemented idiomatically in Ruby (creational, structural, and behavioral patterns)
- Simplifies `plugin.json` by removing explicit arrays in favor of auto-discovery

## Test plan

- [ ] Verify skills load correctly via `/plugin list`
- [ ] Test cucumber-gherkin skill triggers on relevant keywords
- [ ] Test design-patterns-ruby skill triggers on pattern-related queries
- [ ] Confirm reference files are accessible within skill context

🤖 Generated with [Claude Code](https://claude.com/claude-code)