### PR TITLE
fix(ghpm): use new GitHub Projects API instead of deprecated Classic API

### DIFF
--- a/plugins/ghpm/.claude-plugin/plugin.json
+++ b/plugins/ghpm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ghpm",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "GitHub Project Management workflow for product development: PRD creation, epic/task breakdown, TDD execution, and QA planning",
   "author": {
     "name": "Jeb Coleman"


### PR DESCRIPTION
## Summary

- Fixes deprecated Projects Classic API usage in `/ghpm:create-prd` command
- Updates to use new `gh project item-add` command
- Bumps version to 0.1.2

Closes #107

## Problem

The `create-prd` command was using `gh issue edit --add-project` which relies on the deprecated Projects Classic API. GitHub is sunsetting this API:

```
GraphQL: Projects (classic) is being deprecated in favor of the new Projects experience
```

## Solution

Replace with the new GitHub Projects API:

| Old (Deprecated) | New (Fixed) |
|-----------------|-------------|
| `gh issue edit --add-project "$GHPM_PROJECT"` | `gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "$ISSUE_URL"` |

## Changes

- **Step 7 updated** to use `gh project item-add`
- **Project number lookup** added (new API requires number, not title)
- **Issue URL** used instead of issue number
- **Error handling** updated to mention deprecation warning
- **Version bumped** to 0.1.2

## Test plan

- [x] Run `/ghpm:create-prd` and verify issue is added to project
- [x] Verify no deprecation warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)