### PR TITLE
chore(ghpm): bump version to 0.1.4 (#124)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,7 @@
       "name": "ghpm",
       "source": "./plugins/ghpm",
       "description": "GitHub Project Management workflow for product development: PRD creation, epic/task breakdown, TDD execution, and QA planning",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "author": {
         "name": "Jeb Coleman"
       }

--- a/plugins/ghpm/.claude-plugin/plugin.json
+++ b/plugins/ghpm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ghpm",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "GitHub Project Management workflow for product development: PRD creation, epic/task breakdown, TDD execution, and QA planning",
   "author": {
     "name": "Jeb Coleman"


### PR DESCRIPTION
Closes #124

## Summary

- Bumps `plugins/ghpm/.claude-plugin/plugin.json` from 0.1.3 to 0.1.4
- Syncs `.claude-plugin/marketplace.json` from 0.1.0 to 0.1.4

## What's New in 0.1.4

The Issue Claiming workflow (Epic #109):
- Commands assign user and post audit comment before work begins
- Prevents duplicate work on tasks
- Project status updates to "In Progress" (best-effort)
- Conflict detection and orphaned state warnings

## Verification

- [x] Both version files updated to 0.1.4
- [x] Versions are now in sync

---

Generated with [Claude Code](https://claude.com/claude-code)