### PR TITLE
chore(ghpm): bump version to 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,7 @@
       "name": "ghpm",
       "source": "./plugins/ghpm",
       "description": "GitHub Project Management workflow for product development: PRD creation, epic/task breakdown, TDD execution, and QA planning",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "author": {
         "name": "Jeb Coleman"
       }


### PR DESCRIPTION
## Summary
- Bump ghpm plugin version from 0.1.4 to 0.2.0 in marketplace.json
- Reflects addition of quick-issue command feature

## Test plan
- [ ] Verify marketplace.json is valid JSON
- [ ] Confirm version bump displays correctly in plugin marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)