### PR TITLE
chore(ghpm): bump version to 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,7 @@
       "name": "ghpm",
       "source": "./plugins/ghpm",
       "description": "GitHub Project Management workflow for product development: PRD creation, epic/task breakdown, TDD execution, and QA planning",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Jeb Coleman"
       }

--- a/plugins/ghpm/.claude-plugin/plugin.json
+++ b/plugins/ghpm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ghpm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "GitHub Project Management workflow for product development: PRD creation, epic/task breakdown, TDD execution, and QA planning",
   "author": {
     "name": "Jeb Coleman"


### PR DESCRIPTION
## Summary
- Increment ghpm plugin version to 0.3.0 after adding CI check agent feature
- Update both plugin.json and marketplace.json to keep versions in sync

## Test plan
- [ ] Verify plugin.json shows version 0.3.0
- [ ] Verify marketplace.json ghpm entry shows version 0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)