### PR TITLE
Add Sherlock skill

### DIFF
--- a/plugins/general/skills/sherlock/SKILL.md
+++ b/plugins/general/skills/sherlock/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: sherlock
+description: Solve the mystery behind a bug, error, incident, or customer-reported problem — from any source (Sentry/Honeybadger alert, Zendesk or CX ticket, GitHub issue, pasted stack trace, log excerpt, or just a verbal description). Gathers evidence, checks boring explanations first, reproduces when feasible, runs git archaeology, forms and actively falsifies competing hypotheses, and — when the evidence supports it — declares the verified root cause and proposes a concrete fix. Use sherlock whenever the user asks to investigate, diagnose, debug, figure out, look into, get to the bottom of, troubleshoot, RCA, or find the root cause of a bug/error/crash/alert/incident/ticket, especially when the cause is not obvious or the user wants rigor rather than a guess. Prefer sherlock over ad-hoc debugging whenever the user's framing suggests "why is this happening" rather than "change this code".
+---
+
+# Sherlock
+
+Most debugging goes wrong in the same way: the investigator finds the first plausible cause, declares victory, ships the patch — and the bug comes back, because the first plausible cause is almost never the root cause. It's a frame in the stack trace. It's what *fired the gun*, not what *loaded it*.
+
+Sherlock exists to break that habit. Given an issue from any source — a Sentry alert, a Zendesk ticket, a GitHub issue, a pasted error, or a verbal "this thing is broken" — sherlock runs a disciplined investigation: gather evidence, check the boring explanations first, reproduce, form competing hypotheses, actively try to disprove them, follow the "but why?" chain to bedrock, and separate trigger from cause from contributing factors.
+
+Sherlock is willing to conclude. When a hypothesis is verified by direct observation (reproduced, or mechanistically proven), sherlock says so and names the root cause — and then proposes a concrete fix with tradeoffs. When the evidence isn't there yet, sherlock stops at graded hypotheses rather than guessing. Either way, the deliverable is a report that lets any reader tell, for every claim, whether it was **observed**, **inferred**, or **hypothesized**.
+
+## When sherlock runs
+
+The user hands you any of:
+
+- **A link or ID**: Sentry event, Honeybadger fault, GitHub issue, Linear ticket, Zendesk case
+- **Pasted content**: a stack trace, a log excerpt, a support email
+- **A verbal description**: "users in Germany are getting logged out after 30s"
+
+Your first job is orientation. See `references/source-profiles.md` for what evidence each source type carries and how to extract it.
+
+Ask before starting only if you're missing something load-bearing — most commonly: *which codebase/repo does this concern?* If the user is already in a repo and the evidence points there, assume that's the target.
+
+## The investigator's mindset
+
+Before mechanics, the mindset. These are the qualities that separate great investigators from average ones, and they cost nothing but discipline:
+
+- **Suspicious of your own conclusions.** Assume your current theory is wrong until evidence forces you to accept it. When a finding contradicts the working theory, treat it as the most interesting signal in the investigation, not noise to explain away.
+- **Follow the evidence, not the narrative.** Start from the observed fact and walk outward. Don't start from a theory and hunt for confirmation.
+- **Notice what's missing.** A log line that *should* be there and isn't is as much a clue as one that shouldn't be there and is.
+- **Read the actual thing.** Open the source file. Don't rely on what the function "probably does" based on its name. Don't recall from memory what a line looks like — go look.
+- **Honest about uncertainty.** "I don't know yet" is a valid, valuable statement. Fill gaps with experiments, not plausible-sounding guesses.
+- **Proportionate effort.** A typo doesn't need a timeline. A prod outage does. Match depth to stakes.
+
+These aren't aphorisms to admire — they're the working posture throughout every phase below.
+
+## The workflow
+
+Work through the phases in order. Skipping a phase to save time usually costs more later. If a phase has nothing to produce, write "no relevant signals" in the report rather than omitting it.
+
+### Phase 1 — Orient and ingest
+
+Identify the source type (Sentry, Honeybadger, GitHub issue, Zendesk/CX, pasted content, verbal report). Pull everything the source carries. See `references/source-profiles.md` for source-specific extraction.
+
+Common extractions:
+- **Stack trace** → exact file:line of the top frame, exception class, message (verbatim)
+- **Release / version / commit SHA** → the code that was actually running
+- **Environment** → prod vs staging vs dev (they diverge in small, bug-causing ways)
+- **First-seen / last-seen** → when the bug started (constrains the archaeology window)
+- **Occurrence count / affected users** → scale, which informs priority and cohort analysis
+- **Breadcrumbs / logs / user actions** → what led up to the failure
+
+Use available MCPs where they help (Sentry MCP if present). Otherwise work from whatever the issue body, pasted content, or user description provides.
+
+### Phase 2 — Establish the facts
+
+Before theorizing, write down — in the report draft — exactly what you know:
+
+1. **Symptom** — what observably went wrong, in one sentence.
+2. **Error signal** — exception class, message, stack trace, quoted verbatim.
+3. **Reproduction** — steps to reproduce, or "none provided".
+4. **When** — first-seen timestamp or the user's "started around…".
+5. **Scope** — environments, users, occurrences.
+6. **Reporter's hypothesis** — noted, but treated as *one hypothesis among several*, never as fact.
+
+The reporter's hypothesis is evidence about the reporter, not about the bug. They may be right — but only if the evidence supports it. Investigate it as a hypothesis, not a conclusion.
+
+### Phase 3 — Check the boring explanations first
+
+Before digging deep, spend 5–10 minutes on the mundane causes. Exotic theories are seductive; boring causes are statistically more likely. Run through:
+
+- **Recent deploys, config changes, dependency bumps, infra migrations** — correlate with first-seen timestamp. `git log --since="<first-seen>"` is the starting move.
+- **Clock skew, timezone, encoding, locale, DST** — especially for "only some users" bugs.
+- **Caching** — stale cache, cache at the wrong layer, cache key collision.
+- **Wrong environment** — is the user actually hitting prod? Is the config loaded? Is the feature flag on?
+- **Retry amplification** — one real failure multiplied into a hundred alerts by a retry loop.
+- **Stale build / outdated dependency** — is the running code actually the code you're reading?
+
+If one of these ends the investigation, great — document it and move to Phase 8 (fix). If not, the time was cheap and you've ruled out a big class of causes.
+
+### Phase 4 — Reproduce, isolate, bisect
+
+Reproduction is the single most valuable thing you can get. A theory that can't be reproduced is a guess.
+
+- **Minimal repro.** Strip the failing case until removing one more thing makes the bug disappear. A 10-line repro beats a 1000-line one every time.
+- **Differential analysis.** If you can't reproduce the failure, find the difference between a *working* case and a *failing* one — different user, different environment, different input, different version. The diff is the clue.
+- **Bisection.** If the bug is a regression, `git bisect` between a known-good and known-bad commit. Binary search inputs, dates, users, feature flags — anything with a range.
+
+If reproduction is genuinely impractical (e.g., you're investigating a prod-only Sentry event on your local machine), say so explicitly and record what *would* reproduce it. The investigation continues — but every hypothesis stays unverified until reproduction happens.
+
+### Phase 5 — Scope the code
+
+From stack trace and symptom, build a list of **candidate files and modules**. For each, note *why* it's a candidate (top stack frame, implements the feature, owns the data structure, recently changed).
+
+Also identify:
+- **Entry point** — route, controller, background job, CLI command, webhook, cron, event handler
+- **Likely execution path** — rough sketch from entry to where the symptom manifests
+- **Boundary crossings** — serialization, network, process, thread, transaction. Bugs love boundaries because that's where assumptions get renegotiated.
+- **External dependencies** — DB, cache, third-party API, queue, feature flag
+
+If this list is empty, the evidence isn't specific enough yet. Go back to Phase 1 and note what's missing.
+
+### Phase 6 — Git archaeology
+
+Run git commands *before* opening files in your editor — come to the code with questions already formed.
+
+The essentials, scoped to candidate files:
+
+```bash
+# Recent changes — anything touched recently is suspect
+git log --since="<first-seen-window>" --oneline -- <candidate-files>
+
+# Pickaxe — when did this exact string appear or disappear
+git log -S "<error-message>" --oneline --all
+git log -S "<function-name>" -p -- <candidate-file>
+
+# Line-range history — follow a function through history including renames
+git log -L :<functionName>:<path/to/file>
+
+# Blame with move and whitespace tracking
+git blame -w -C -C -C <path/to/file>
+
+# Bug-fix hotspots in the scope
+git log -i -E --grep='fix|bug|broken|regression' --oneline -- <candidate-files>
+
+# Firefighting signals — reverts, hotfixes
+git log --oneline -i -E --grep='revert|hotfix|emergency|rollback' -- <candidate-files>
+```
+
+Commit messages are hints, not evidence — read the diff, not just the subject line.
+
+For the full toolkit (line-range history, merge-commit inspection, repo-health commands, interpretation notes), see `references/git-archaeology.md`.
+
+### Phase 7 — Read code and correlate
+
+Now open files — with questions, not free-form browsing. For each candidate file, know before opening: *what am I looking for here?*
+
+Trace the execution path from entry point through the stack trace. At each hop:
+- What is this function responsible for?
+- What inputs does it trust vs. validate?
+- What could make it fail in the way the symptom describes?
+- Anything surprising — dead code, commented-out guards, stale comments, silent `rescue`/`except`?
+
+**Correlate in parallel:**
+- **By time** — overlay the incident timeline with deploys, config changes, cron jobs, cert expirations, DST boundaries. "What else happened at 03:47 UTC?" solves bugs.
+- **By cohort** — group affected cases by any attribute: user, region, device, tenant, shard, build, feature-flag state. Look for what the affected share that the unaffected don't.
+- **By pattern** — hash collisions, power-of-2 boundaries, integer overflow thresholds, Unicode edge cases, counts that match pool/batch/thread sizes.
+
+For more on these (and other techniques like tracing, flame graphs, time-travel debugging, invariant auditing), see `references/techniques.md`.
+
+### Phase 8 — Form competing hypotheses and falsify
+
+List at least 2–3 plausible root causes, even when one feels obvious. The goal is *comparison*, not confirmation. For each hypothesis, record:
+
+- **Statement** — one sentence describing the causal claim
+- **Mechanism** — how it would produce the observed symptom
+- **Evidence for** — specific observations (stack frame at X, commit Y changed Z, log W)
+- **Evidence against** — specific observations that don't fit
+- **Status** — one of:
+  - **Verified** — reproduced, or mechanism proven by direct observation
+  - **Unverified** — consistent with evidence but not proven
+  - **Ruled out** — contradicted by direct observation
+  - **Needs investigator input** — requires info outside the codebase (prod data, user action, third-party behavior)
+- **How to verify** — the cheapest experiment that would confirm *or falsify*
+
+Then — and this is the step most investigators skip — **actively try to disprove** your leading hypothesis. Ask: "What would I expect to see if this were true? Do I see it?" and equally "What would I expect to see if this were false? Can I find it?" The disproving mindset is the main defense against confirmation bias.
+
+### Phase 9 — "But why?" to bedrock, and separate trigger from cause
+
+For each non-ruled-out hypothesis, keep asking "but why?" one more time than feels necessary. Example:
+
+> 500 error → because the DB call raised → because a column was null → because a migration that backfills it never ran in this environment → because the migration was gated on a feature flag that's off here.
+
+Stop when the next "why" lands on something immutable (physics, protocol spec, external system contract) or on a human decision someone made.
+
+Then name three things separately:
+
+- **Trigger** — what fired the bug *this time* (the specific input, the specific timing)
+- **Cause** — what made the bug *fireable* (the code path that mishandles that input)
+- **Contributing factors** — what let it reach production (missing test, missed review, absent monitoring, unclear ownership)
+
+A fix that only addresses the trigger leaves the gun loaded. A good report names all three.
+
+### Phase 10 — Verify
+
+If a leading hypothesis is verifiable cheaply, run the verification. This is where the investigation earns the word "solved":
+
+- Reproduce the bug with the minimal repro.
+- Run the code in a debugger and watch the failing state.
+- Add a temporary log line that would only fire if the hypothesis is true, and confirm it fires.
+- Revert the suspected commit in a branch and confirm the bug goes away.
+
+When verification succeeds, upgrade the hypothesis to **Verified** and call it the root cause. When it fails, the hypothesis is **Ruled out** and you have new evidence for the remaining ones.
+
+"Verified" is a high bar. If you haven't literally run code or observed the failure mechanism, the hypothesis is not verified — it's a strong hypothesis. Err toward honesty: unverified is fine, fake-verified is not.
+
+### Phase 11 — Decide: conclude, or stop at hypotheses
+
+Two honest endings:
+
+**Mystery solved.** A hypothesis is verified. The report names the root cause, the trigger, and the contributing factors, and **proposes a concrete fix** (see next section).
+
+**Mystery narrowed.** No hypothesis is verified yet, but some are ruled out and others are graded. The report presents the remaining hypotheses, explains what would verify each, and recommends the cheapest next step (often: reproduce in a specific way, or ask the user a specific question).
+
+Do not fake certainty to land at "solved". A well-narrowed mystery is more valuable than a falsely-resolved one.
+
+### Phase 12 — Propose the fix (only when verified)
+
+When the root cause is verified, propose a fix. Otherwise skip this section.
+
+A good fix proposal:
+
+- **Addresses the cause, not just the trigger.** If the trigger is "user submitted empty string" and the cause is "code path doesn't validate input", the fix is the validation, not an input sanitizer on one caller.
+- **Names the remediation shape before the code.** "Revert commit X", "add a null check at Y:123", "backfill the missing column in a migration gated on feature flag F". The shape is often more important than the exact diff.
+- **Acknowledges tradeoffs.** Revert vs. forward-fix. Narrow patch vs. broader refactor. Defensive check vs. fixing the producer. Name the choice you're recommending and why.
+- **Addresses contributing factors separately.** A missing test or absent monitoring often deserves its own task — note it but don't bundle it into the primary fix unless the user wants that.
+- **Flags risk.** Is this fix cheap and safe, or does it touch a hot path? Will it need a backfill? Does it need a feature flag?
+
+Do not write the patch unless asked — propose the shape and let the user decide whether to proceed to implementation. This is deliberate: it keeps the investigation cleanly separated from the fix decision.
+
+### Phase 13 — Write the report
+
+Use the template in `references/report-template.md`. Save to `investigation-report.md` in the current working directory (or a path the user specifies). Do not post it anywhere — the user decides where it goes.
+
+The report is the deliverable. Its single most important job: for every claim, the reader can tell whether you *saw it*, *inferred it*, or *suspect it*. Use the status labels (Verified / Unverified / Ruled out / Needs investigator input) exactly as defined.
+
+## Failure modes to watch for
+
+These are the specific ways investigations go wrong. Every one of them has cost somebody a week.
+
+- **Anchoring on the reporter's hypothesis.** If the ticket says "I think it's the cache", you'll be tempted to only investigate the cache. List it as *one of several*.
+- **Stopping at first-plausible.** A hypothesis that fits the top frame of the stack trace is the *start* of "but why?", not the end.
+- **Confirmation bias in code reading.** You'll pattern-match code that supports your current theory. Deliberately look for code that *contradicts* it.
+- **Inferring dynamic behavior from static code.** "This branch is never taken" — are you sure? What logs or tests would confirm that? If you can't confirm, it's an unverified hypothesis, not a fact.
+- **Treating high churn as guilt.** A churn-heavy file is a signal, not a verdict. Read the commits, don't just cite the count.
+- **Shotgun debugging.** Changing many things at once and hoping one works produces superstition, not understanding. Change one thing at a time.
+- **Tunneling on a wrong theory.** If three hypotheses in a row die, the *framing* is probably wrong — step back and re-read the original symptom before going deeper.
+- **Skipping the boring check.** Nine times out of ten, the "impossible" thing is very possible and your map was wrong. Check that the code is actually running, the config is loaded, the flag is on.
+- **Verifying by wishful thinking.** "Seems to match" is not verification. Reproduction, debugger observation, or a targeted log line is verification.
+- **Bundling fix into investigation.** Proposing a fix *before* the root cause is verified biases hypothesis selection toward fixable-looking causes. Verify first, propose second.
+
+## Reference files
+
+- `references/source-profiles.md` — evidence shapes and extraction tips for Sentry, Honeybadger, GitHub issues, Zendesk/CX tickets, and raw inputs
+- `references/techniques.md` — broader investigator toolkit (minimal repro, bisection, differential, tracing, flame graphs, time-travel debugging, invariant auditing, rubber duck, timeboxing)
+- `references/git-archaeology.md` — full git command reference for investigation
+- `references/report-template.md` — the exact report structure to use
+
+Read a reference file when you need it. You don't need to read them all upfront.

--- a/plugins/general/skills/sherlock/references/git-archaeology.md
+++ b/plugins/general/skills/sherlock/references/git-archaeology.md
@@ -1,0 +1,212 @@
+# Git Archaeology — Command Reference
+
+A toolkit for extracting history-based evidence about a codebase before (or during) reading its code. Inspired by Drew Piechowski's "5 Git Commands I Run Before Reading Any Code", expanded with commands specifically useful for bug investigation.
+
+Not every command belongs in every investigation. Pick the ones that answer a question you actually have. Running commands for their own sake is noise.
+
+---
+
+## Table of contents
+
+1. [Scoped-to-the-bug commands](#scoped-to-the-bug-commands) — the ones you'll reach for most during an investigation
+2. [Repo-health commands](#repo-health-commands) — the five from the original article, useful for broader context
+3. [Reading git output](#reading-git-output) — what the signals actually mean
+
+---
+
+## Scoped-to-the-bug commands
+
+These answer questions about the specific files, functions, and code paths implicated in the issue.
+
+### Recent changes to the scope
+
+Anything touched recently is suspect, especially if the issue's first-seen timestamp is recent.
+
+```bash
+git log --since="3 months ago" --oneline -- <candidate-files>
+git log --since="3 months ago" --stat -- <candidate-files>   # with file change sizes
+git log -p --since="3 months ago" -- <single-file>           # full diffs
+```
+
+Adjust the `--since` window to match when the bug started appearing. If the issue says "started Tuesday", use `--since="1 week ago"`.
+
+### Pickaxe: when did this exact string appear or disappear
+
+Finds commits that *added or removed* the given string. Excellent for locating the commit that introduced an error message, config key, function name, or SQL snippet.
+
+```bash
+git log -S "<exact-string>" --oneline --all
+git log -S "<exact-string>" -p --all            # with the diffs showing context
+git log -S "<exact-string>" -p -- <file-glob>   # scoped to files
+```
+
+`-G "<regex>"` is the regex variant — use it for patterns (`-G "class\s+FooBar"`).
+
+**Common uses in bug investigation:**
+- Error message from a stack trace → when/where it was introduced
+- Config flag name → when it was added, last changed
+- Function that shouldn't exist anymore → when it was removed (try with `--all`)
+
+### Line-range history
+
+Follows a specific function (or line range) through its full history, including renames.
+
+```bash
+git log -L :<functionName>:<path/to/file>
+git log -L <start>,<end>:<path/to/file>
+```
+
+Shows every commit that modified the named function with the diff. Especially useful when you know *which function* is suspicious but not *when* it last changed meaningfully.
+
+### Blame with move- and whitespace-tracking
+
+Default `git blame` is naive — it attributes lines to the commit that last touched them, even if that was a whitespace reformat or a code move. This variant is much more informative:
+
+```bash
+git blame -w -C -C -C <path/to/file>
+```
+
+- `-w` ignores whitespace changes
+- `-C -C -C` tracks code movement within the file, between files in the same commit, and across any commits (progressively more aggressive)
+
+For a specific line range: `git blame -L 45,80 -w -C -C -C <file>`.
+
+### Churn inside the scope
+
+Files that churn a lot often contain bugs (the Microsoft Research result cited in the Piechowski article). Inside your candidate set, a file with disproportionate churn deserves extra attention.
+
+```bash
+git log --format=format: --name-only --since="1 year ago" -- <candidate-files> | sort | uniq -c | sort -nr
+```
+
+### Bug-message hotspots in the scope
+
+Has this area been patched for bugs before? What kind?
+
+```bash
+git log -i -E --grep='fix|bug|broken|regression|patch' --oneline -- <candidate-files>
+git log -i -E --grep='fix|bug|broken|regression|patch' -p -- <candidate-file>  # with diffs
+```
+
+Read the commit messages — if you see "fix null check in X" appearing three times on different years, that area has a known pattern of defects.
+
+### Firefighting signals
+
+Reverts and hotfixes near the scope indicate an unstable area.
+
+```bash
+git log --oneline -i -E --grep='revert|hotfix|emergency|rollback' -- <candidate-files>
+```
+
+A revert near your scope is a direct lead — read both the revert commit and the commit it reverted.
+
+### Related commits across the whole repo
+
+Search commit messages for concepts from the issue. Useful when the scope is fuzzy or when similar bugs may have been fixed elsewhere.
+
+```bash
+git log -i --grep="<concept-word-from-issue>" --oneline
+git log -i --grep="<concept-word>" --since="1 year ago" --stat
+```
+
+Examples of useful concept words: the feature name, the name of the user-facing object, the symptom ("timeout", "duplicate", "encoding"), the environment ("staging", "prod").
+
+### Regression origin via bisect
+
+If the issue says "worked before, broke after date/version X", bisect narrows the introducing commit.
+
+```bash
+git bisect start
+git bisect bad <known-bad-commit>      # often HEAD
+git bisect good <known-good-commit>    # the last version where it worked
+# Then for each commit git checks out, either run an automated test
+# or manually reproduce and run:
+git bisect good   # or: git bisect bad
+git bisect reset  # when done
+```
+
+Automation with `git bisect run <script>` is powerful — the script should exit 0 for good, non-zero for bad, and 125 to skip a commit that can't be tested. In practice, writing a reliable reproducer script is often the hard part of a bisect.
+
+If a bisect is impractical (no reproducer, too expensive to test each commit), note in the report that bisect is a recommended next step and provide the candidate range.
+
+### Merge commits in the scope
+
+Sometimes a bug is introduced not by a direct commit but by a bad merge.
+
+```bash
+git log --merges --oneline --since="3 months ago" -- <candidate-files>
+git log --first-parent --oneline --since="3 months ago" -- <candidate-files>  # main-branch view
+```
+
+### Show a specific commit in full
+
+```bash
+git show <sha>              # message + diff
+git show --stat <sha>       # message + file list
+git show <sha> -- <file>    # just the diff for one file
+```
+
+---
+
+## Repo-health commands
+
+The five commands from the Piechowski article. These give a broader picture of the codebase's condition. Useful for context but less directly tied to a specific bug — include them in the investigation only when relevant.
+
+### 1. Highest-churn files (last year)
+
+```bash
+git log --format=format: --name-only --since="1 year ago" | sort | uniq -c | sort -nr | head -20
+```
+
+The top 20 most-changed files. Cited Microsoft Research finding: churn predicts defects more reliably than complexity alone. If a candidate file is in this top-20, that's meaningful context.
+
+### 2. Contributor concentration (bus factor)
+
+```bash
+git shortlog -sn --no-merges
+git shortlog -sn --no-merges --since="6 months ago"   # recent activity only
+```
+
+Red flags: one person >60% of commits, key contributors absent for 6+ months, many historical contributors but only a handful recently active. Relevant for investigation when the suspect code has a narrow set of authors who may or may not still be around to consult.
+
+### 3. Bug hotspots (repo-wide)
+
+```bash
+git log -i -E --grep="fix|bug|broken" --name-only --format='' | sort | uniq -c | sort -nr | head -20
+```
+
+The files that appear most often in bug-fix commits. Cross-reference with the churn list — files that are both high-churn *and* high-bug are "the risky ones".
+
+### 4. Project velocity
+
+```bash
+git log --format='%ad' --date=format:'%Y-%m' | sort | uniq -c
+```
+
+Commit counts per month. Steady rhythm suggests a healthy team; sharp drops or cliffs may explain why an area feels neglected.
+
+### 5. Firefighting across the repo
+
+```bash
+git log --oneline --since="1 year ago" | grep -iE 'revert|hotfix|emergency|rollback'
+```
+
+High counts indicate deploys lack confidence. Zero counts may mean stability *or* poor commit-message discipline — interpret alongside other signals.
+
+---
+
+## Reading git output
+
+A few interpretation notes that tend to trip people up:
+
+**Churn alone doesn't mean bad code.** Configuration files, dependency manifests, and translation files churn legitimately. The signal is churn *combined with* complexity, bug-fix density, or recent incidents.
+
+**Blame is provenance, not blame.** `git blame` answers *when* and *by whom* a line was last changed — not whether that change caused the bug. A line untouched for five years can still be where the bug manifests.
+
+**Absence of bug-fix commits doesn't mean no bugs.** It may mean commit messages don't use words like "fix" or "bug". Look at the actual diffs of recent commits, not only the messages.
+
+**Commit messages lie (or at least flatter).** Engineers (and AI assistants) write commit messages after the fact; they describe what the author *thinks* they did. For load-bearing claims, read the diff, not the message.
+
+**The first-plausible commit is rarely the root.** Pickaxe may show a suspicious commit that introduced the string — but the bug might predate it and the commit merely exposed it. Treat every archaeological finding as a hypothesis to verify against the code's actual behavior.
+
+**Don't trust tags/releases alone for "when did this break".** A user saying "it broke on Tuesday" may mean "I noticed on Tuesday". The actual regression may be older. Cross-reference with Sentry/Honeybadger first-seen timestamps when available.

--- a/plugins/general/skills/sherlock/references/report-template.md
+++ b/plugins/general/skills/sherlock/references/report-template.md
@@ -1,0 +1,113 @@
+# Report Template
+
+Save investigations as `investigation-report.md` in the current working directory (or a path the user specifies). Use this exact structure — the labeled sections are part of the contract. They set reader expectations about what kind of claim each section contains.
+
+---
+
+```markdown
+# Investigation: <issue title or one-line symptom>
+
+## Summary
+Two or three sentences stating the known facts and the current state of the
+investigation. If a root cause is verified, state it here explicitly. If not,
+state the leading hypothesis *as a hypothesis*, not as "the cause".
+
+## What was reported
+- **Source**: <Sentry / Honeybadger / GitHub issue / Zendesk / pasted / verbal>
+- **Symptom**: <one line>
+- **Error signal**: <exception / stack trace / log, quoted verbatim in a code block>
+- **Reproduction**: <steps, or "none provided">
+- **First seen / scope**: <timestamp, environment, user/occurrence count if known>
+- **Reporter's hypothesis**: <noted separately; one hypothesis among others>
+
+## Boring-explanations check
+Which mundane causes were considered and what was ruled out. Examples: recent
+deploys, config changes, caching, clock/timezone/encoding, retry amplification,
+feature-flag state. If one of these *was* the cause, say so here and proceed
+directly to Root cause.
+
+## Scope of investigation
+Files, modules, and execution paths examined, each with a one-line *why it's in scope*.
+
+## Reproduction
+Steps that reliably reproduce the bug, or an explanation of why reproduction
+was not attainable (and what would be needed to reproduce).
+
+## Git archaeology findings
+Recent changes, churn, blame observations, pickaxe results, prior bug-fix
+commits, firefighting patterns. Quote commit SHAs. If a signal was looked for
+and not found, say so — absence is information.
+
+## Code-reading observations
+Facts about the code, with file:line references. Keep this descriptive and
+evidence-grounded. Flag anything that looked odd but wasn't conclusive.
+
+## Correlation findings
+Time-based, cohort-based, or pattern-based observations. "All affected users
+are on v1.8.3", "incident started 12 minutes after deploy of X", "failure
+count matches the connection pool size of 20".
+
+## Hypotheses
+
+### H1: <short name>
+- **Status**: Verified | Unverified | Ruled out | Needs investigator input
+- **Mechanism**: how this would produce the symptom
+- **Evidence for**: …
+- **Evidence against**: …
+- **How to verify further**: concrete next step (omit if already Verified/Ruled out)
+
+### H2: …
+### H3: …
+
+## Ruled out
+Hypotheses that looked plausible but were contradicted by evidence, each with
+the specific observation that ruled it out.
+
+## Root cause
+[Include this section ONLY if a hypothesis was verified by direct observation.
+Otherwise omit.]
+
+- **Cause**: what makes the bug fireable (the code path, the missing check,
+  the mishandled case)
+- **Trigger**: what fired it *this time* (the specific input, timing, user action)
+- **Contributing factors**: what let it reach production (missing test,
+  missed review, absent monitoring, unclear ownership)
+- **Verification**: how this was confirmed — the reproduction, the debugger
+  observation, the targeted log line, the reverted commit
+
+## Proposed fix
+[Include this section ONLY if Root cause is verified. Otherwise omit.]
+
+- **Shape**: the remediation in one or two sentences before any code
+  ("revert commit X", "add null check at Y:123 and backfill missing data")
+- **Tradeoffs**: revert vs forward-fix, narrow patch vs broader refactor,
+  defensive check vs fixing the producer — name the choice and why
+- **Risk**: is this cheap and safe, or does it touch a hot path? Will it
+  need a backfill, feature flag, coordinated deploy?
+- **Separate follow-ups**: contributing factors that deserve their own tasks
+  (a missing test, an absent alert), listed but not bundled in
+
+## Open questions for the investigator
+Specific things that could not be answered from code + git + available logs
+alone. Phrased as questions, not tasks.
+
+## Evidence quality note
+Explicitly call out which claims in this report are direct observation vs.
+inference vs. hypothesis. Flag anything the next reader should *not* treat as
+established.
+
+## Not included
+- <If Root cause is not verified: "No fix is proposed — see graded hypotheses above.">
+- <If Root cause is verified: "Patch not written — fix shape proposed, implementation is a separate task.">
+- <Any areas intentionally not explored, and why.>
+```
+
+---
+
+## Writing guidelines
+
+- **Verbatim quoting.** Error messages, log lines, and SQL queries go in fenced code blocks, quoted exactly. Do not paraphrase error messages — the exact wording is often the searchable key.
+- **Concrete references.** Every code claim gets a `path/to/file.ext:123` reference. Every historical claim gets a commit SHA.
+- **Status labels are sacred.** Do not use "probably", "likely", "seems to be" as a substitute for a status label. If a claim is causal, it gets Verified / Unverified / Ruled out / Needs investigator input — full stop.
+- **Absence is information.** If you checked for something and didn't find it, write "no firefighting commits in the last year" or "no related Sentry events for this user". A silent omission reads as "not checked".
+- **Two endings only.** Either a verified root cause (with a fix proposal) or a set of graded hypotheses (without). Do not smuggle a half-confident conclusion in between.

--- a/plugins/general/skills/sherlock/references/source-profiles.md
+++ b/plugins/general/skills/sherlock/references/source-profiles.md
@@ -1,0 +1,152 @@
+# Source Profiles — What Evidence Each Input Carries
+
+Issue reports arrive from many sources, and each source has a different *evidence profile* — what it reliably gives you and what you have to extract, translate, or go ask for. Name the profile before you start investigating; it tells you what you already have and what you're missing.
+
+---
+
+## Sentry
+
+**Evidence profile**: exception-oriented, technical, often high-signal.
+
+**Reliably provided**:
+
+- Exception class, exception message
+- Stack trace with file:line (may be minified for frontend — check for source maps)
+- Release / version (the deployed artifact that threw)
+- Environment (production / staging / etc.)
+- Runtime / SDK info, user agent, OS
+- First-seen, last-seen timestamps
+- Event count, affected user count
+- Breadcrumbs — the sequence of events leading up to the exception (clicks, navigations, log lines, HTTP calls)
+- Tags (custom — varies by project)
+
+**Extraction tips**:
+
+- The **top frame** of the stack trace is usually the file to read first, but not always the cause. The cause is often a few frames deeper in the app code.
+- **Breadcrumbs** are the closest thing to a free reproduction: the sequence of user actions and side effects right before the crash.
+- **Release** is crucial — it tells you which commit was actually running. `git log <release>` for the real code.
+- **Occurrence rate over time** distinguishes a spike (new regression) from a chronic issue (long-standing bug).
+
+**Common pitfalls**:
+
+- Minified JS stack traces are useless without source maps. Check whether source maps are uploaded.
+- "Affected users: 1, Events: 5000" usually means one user in a retry loop — don't treat event count as severity.
+- First-seen is when Sentry first saw it, which may be after the bug was introduced. Correlate with deploys.
+
+**If a Sentry MCP is available**, use it to pull full event details, breadcrumbs, and related events.
+
+---
+
+## Honeybadger
+
+**Evidence profile**: similar to Sentry — exception-oriented.
+
+**Reliably provided**:
+
+- Exception class + message
+- Stack trace
+- Request context (URL, method, params, headers — often richer than Sentry for Rails apps)
+- Environment
+- First-seen, occurrence count
+- User/session context if the app instruments it
+- Similar-faults grouping
+
+**Extraction tips**:
+
+- Honeybadger's **request params** are often the missing piece — they give you the exact input that triggered the error. Check for sensitive-data filtering, though.
+- **Similar faults** — Honeybadger groups by fingerprint. Check whether this is one of a cluster or a singleton.
+
+---
+
+## GitHub Issue
+
+**Evidence profile**: highly variable — depends entirely on the reporter.
+
+**Reliably provided**:
+
+- Title, body, labels
+- Comments (often where the real discussion lives)
+- Linked PRs, commits, other issues
+- Author, reactions, assignees
+
+**Extraction tips**:
+
+- Use `gh issue view <num> --comments` to get everything in one pull.
+- **Linked PRs closing the issue** — if the issue is closed, the linking PR is ground truth for the fix. Don't read it first (it biases your hypotheses), but do check your conclusions against it at the end.
+- **"Same as #123" / "Duplicate of"** — related issues may have richer evidence than the one in front of you.
+- Developer-authored issues often contain a hypothesis already. Note it as **one** hypothesis, not as fact.
+
+**Common pitfalls**:
+
+- Issue bodies often contain a *translation* of the real error (paraphrase, partial screenshot) rather than the verbatim error. Push back if the stack trace or exact message is missing.
+- "It started happening around Tuesday" usually means *noticed* on Tuesday. Cross-reference with error-tracker first-seen.
+
+---
+
+## Zendesk / CX ticket / Support email
+
+**Evidence profile**: user-facing, low-signal for code, high-signal for symptom.
+
+**Reliably provided**:
+
+- User-facing symptom in natural language ("can't upload", "got a weird email")
+- Partial reproduction steps (maybe)
+- Screenshots (maybe)
+- User metadata (account, plan, region)
+- Back-and-forth with support agent (sometimes hides clarifying details in later messages)
+
+**Usually missing**:
+
+- Stack trace
+- Exact timestamps precise enough to correlate with deploys
+- Precise reproduction steps
+- Server-side logs
+
+**Extraction tips**:
+
+- **Translate the symptom into a code region.** "Can't upload" → what upload flow? File type? Size? Endpoint? This is the investigator's main job for CX-sourced issues: go from user-language to a candidate file list.
+- **Ask for the missing evidence** before going deep. Often a 5-minute ask to the CX team for "exact timestamp, exact error message they saw, which button they clicked" saves hours.
+- **Cross-reference** with Sentry/Honeybadger by user ID and time window — a CX report without an error-tracker hit means either silent failure (important!) or the error was caught and handled incorrectly.
+- **Screenshots** sometimes show URLs, request IDs, or console errors — zoom in.
+- Re-read the *full* ticket thread. The useful detail is often in message #4, not the initial report.
+
+**Common pitfalls**:
+
+- Users report workarounds as symptoms. "I have to refresh three times" — the bug is whatever makes the first two attempts fail, not the refresh.
+- Users conflate effects. "The dashboard is broken" might mean: a chart renders empty, a filter doesn't apply, a tooltip is garbled. Pin down *which* observable thing is wrong.
+
+---
+
+## Pasted content (stack trace, log excerpt, email thread)
+
+**Evidence profile**: whatever the user decided to paste — often incomplete.
+
+**Extraction tips**:
+
+- Ask: *is this the whole thing, or an excerpt?* Excerpts often omit the line that would have told you the answer.
+- Look for **release/version/environment markers** — log prefixes, build IDs, host names.
+- Look for **timestamps** — multi-line logs often have them; they let you correlate with deploys.
+- If you see a **stack trace**, treat it like a Sentry stack trace (top frame → candidate file, etc.).
+- If you see **request IDs or trace IDs**, note them — the user may be able to pull the full trace from their observability tool.
+
+---
+
+## Verbal / prompt-only ("users in Germany get logged out after 30s")
+
+**Evidence profile**: pure symptom description, no artifacts.
+
+**Extraction tips**:
+
+- Translate into hypothesis-generating questions: *only Germany* → geo/locale/CDN/region split. *After 30s* → timeout at some layer (LB, app, DB, session). *Logged out* → session invalidation (which code path?).
+- **Ask early.** "Do you have a Sentry link, a timestamp, a user who reproduced it, an exact error they saw?" A 2-minute ask beats an hour of speculation.
+- **Name what's missing explicitly** in the report. "No error signal available" is itself a finding — it either means it's being caught silently or it's a non-exception failure (wrong data, wrong UI state, etc.).
+
+---
+
+## Cross-source patterns
+
+Some patterns hold across all sources:
+
+- **Two reports, same root cause, different surfaces.** A Sentry spike at 14:00 and a CX ticket at 14:05 mentioning the same user flow are almost certainly the same incident. Check.
+- **Missing evidence is evidence.** A CX ticket with no matching Sentry hit means either silent failure or the error is in a path that isn't instrumented. Both are worth flagging.
+- **Reporter's hypothesis ≠ root cause.** The reporter may be right. They're more often not, even when they're technical. Treat any hypothesis as one to verify, not one to confirm.

--- a/plugins/general/skills/sherlock/references/techniques.md
+++ b/plugins/general/skills/sherlock/references/techniques.md
@@ -1,0 +1,283 @@
+# Investigator Techniques
+
+A toolkit — not a checklist. Great investigators have a toolkit and match the technique to the shape of the bug. Reach for what fits the evidence you have; ignore what doesn't. The phases in SKILL.md tell you *when* to use these; this file tells you *how*.
+
+## Table of contents
+
+1. [Reproduction and isolation](#reproduction-and-isolation)
+2. [Bisection](#bisection)
+3. [Differential analysis](#differential-analysis)
+4. [Correlation](#correlation)
+5. [Observation (logs, tracing, debugger)](#observation)
+6. [System-level inspection](#system-level-inspection)
+7. [Hypothesis discipline](#hypothesis-discipline)
+8. [Meta-techniques](#meta-techniques)
+
+---
+
+## Reproduction and isolation
+
+### Minimal reproduction
+
+Strip the failing case until removing one more thing makes the bug disappear. Every variable you remove without breaking the repro is a hypothesis you don't have to investigate.
+
+- A 10-line repro beats a 1000-line one every time.
+- Start from the full failing case; halve it repeatedly.
+- Each removed input or line that *didn't* change the outcome is a dead end ruled out.
+
+### Isolation
+
+Separate the bug from its environment. Does it reproduce:
+
+- Locally vs only in prod?
+- With this user's data vs a clean account?
+- On this branch vs main?
+- On this machine vs a colleague's?
+
+Each isolation dimension that the bug *doesn't* survive tells you where it lives.
+
+---
+
+## Bisection
+
+Binary search turns an O(n) hunt into O(log n). Use it whenever you have a range.
+
+### Git bisect
+
+When a bug is a regression — it worked, now it doesn't — bisect the commit range.
+
+```bash
+git bisect start
+git bisect bad <known-bad-commit>      # often HEAD
+git bisect good <known-good-commit>    # last known-working
+# For each checkout, reproduce manually or run:
+git bisect good   # or: git bisect bad
+git bisect reset  # when done
+```
+
+With a scriptable reproducer, `git bisect run <script>` automates the whole thing: exit 0 for good, non-zero for bad, 125 to skip.
+
+Writing the reproducer is usually the hard part. If reproduction is expensive, bisect manually on a coarser grid (every 10th commit, every merge to main) and narrow from there.
+
+### Non-git bisection
+
+The same technique applies to any range:
+
+- **Inputs** — halve the input file, the request body, the dataset
+- **Config** — flip flags in a binary search over configuration space
+- **Users / tenants** — if only some are affected, split the cohort
+- **Time** — if it started "sometime last week", binary-search across hours of logs
+- **Releases** — for versioned artifacts, bisect by version
+
+---
+
+## Differential analysis
+
+When you have both a failing case and a working case, **the diff is the clue**. "What's different?" is often a faster question than "What's wrong?".
+
+Axes to compare:
+
+- **Environment** — staging vs prod. Diff the config, the data, the versions.
+- **User** — affected vs unaffected. What do affected users share that unaffected ones don't?
+- **Time** — before vs after. What changed at the boundary?
+- **Version** — v1.2 vs v1.3. `git diff v1.2..v1.3 -- <candidate-files>`
+- **Request** — a failing request vs a similar-looking passing one. Diff headers, body, user context.
+
+If the cohort of affected users is 100% or 0% along some dimension (region, device, plan tier), that dimension is almost always load-bearing.
+
+---
+
+## Correlation
+
+### Correlation by time
+
+Overlay the incident timeline with everything else that happened around the same time:
+
+- Deploys
+- Config / feature-flag changes
+- Dependency bumps / infra migrations
+- Cron jobs
+- Scheduled tasks / batch jobs
+- Certificate expirations
+- DST transitions / timezone boundaries
+- Traffic spikes / load shifts
+
+"What else happened at 03:47 UTC?" has solved countless mysteries. Check dashboards side-by-side at the same time range.
+
+### Correlation by cohort
+
+Group failing cases by any attribute:
+
+- User, account, tenant
+- Region, IP range, CDN PoP
+- Device, browser, OS version
+- App version, build, deploy region
+- Feature flag state
+- Plan tier, role
+- Data shape (row count, payload size)
+
+A cohort that's 100% affected or 0% affected is a strong signal. A roughly even split often means timing or load.
+
+### Correlation by pattern
+
+Some bugs have numeric fingerprints:
+
+- **Hash collisions** — if affected IDs share a modulo, suspect routing or sharding
+- **Power-of-2 boundaries** — 256, 512, 1024, 65536, ... → integer limits, buffer sizes
+- **Integer overflow thresholds** — 2^31 - 1, 2^63 - 1
+- **Unicode edge cases** — emoji, surrogate pairs, RTL text, combining characters, BOM
+- **Pool / batch / thread size matches** — failure count matching connection pool size, thread count, or batch size tells you the scaling axis
+- **Periodicity** — every 60s, every 1000 requests, every hour — points at scheduled work, caching intervals, or token refresh
+
+---
+
+## Observation
+
+### Strategic logging
+
+Logs work when they're placed at decision points, not entry/exit alone. Good logs record:
+
+- Which branch was taken (and why — the values that drove the decision)
+- What the code thinks it's about to do, right before doing it
+- What it actually observed from dependencies (DB row count, API status code, cache hit/miss)
+
+Remove noisy logs before adding new ones — signal dies in noise.
+
+### Tracing
+
+- **Distributed tracing** (OpenTelemetry, Datadog, Jaeger) — for request-path bugs. A span missing from a trace *is* the finding.
+- **strace / dtrace** — syscall-level, for "what is this process actually doing?"
+- **tcpdump / Wireshark** — network level, for "client or server?" bugs
+
+Sampling traces lie about rare events — use head-based or tail-based sampling deliberately.
+
+### Debugger
+
+Prefer a debugger to print statements when the state you care about is structured.
+
+- Set a breakpoint where you expect the state to diverge from expectation; walk up the stack.
+- **Conditional breakpoints** for intermittent bugs (`when i == 4732`, `when user_id == "abc"`).
+- **Post-mortem** on core dumps when you can't reproduce live.
+
+### Time-travel debugging
+
+Tools like `rr` (Linux), Pernosco, UndoDB: record once, replay deterministically, step backward from the failure. Invaluable for Heisenbugs and state-corruption bugs. Underused because it requires setup; pays for itself on the first hard bug.
+
+---
+
+## System-level inspection
+
+For bugs that aren't obviously in app code:
+
+### Process and resource inspection
+
+- `ps`, `top`, `htop`, `iostat`, `vmstat` — what's running, using what
+- `netstat` / `ss` — open sockets, listening ports, connection states
+- `/proc/<pid>/` on Linux — fds, memory maps, status, limits
+- `lsof` — what a process has open when it's stuck
+
+### Stack dumps and flame graphs
+
+- **Thread dumps** for deadlocks and stuck threads — take three, 10 seconds apart, compare
+- **CPU flame graphs** (`perf`, `async-profiler`, `py-spy`) for "why is this slow?"
+- **Off-CPU flame graphs** for "why is this *waiting*?" — often the more important question
+
+### Network-layer inspection
+
+- `curl -v` — see headers, redirects, TLS handshake
+- `openssl s_client -connect host:443` — TLS issues, cert expiration
+- `dig +trace` — DNS resolution path
+- `mtr` — combined traceroute + ping
+- Packet capture when "is it the client or the server?" matters
+
+---
+
+## Hypothesis discipline
+
+### The disproving mindset
+
+For every hypothesis, design the cheapest experiment that would **falsify** it. If you can't design a falsifying test, the hypothesis isn't specific enough.
+
+Confirmation bias is the investigator's main enemy. Hunt for your theory's counterexample *first*. If you can't find one despite trying, your confidence in the theory goes up honestly.
+
+### One change at a time
+
+When multiple fixes land together and it works, you don't know which one fixed it. Discipline:
+
+- Revert to baseline
+- Apply one change
+- Test
+- If still broken, revert and try the next
+- Only combine changes after each is individually understood
+
+Shotgun debugging produces superstition, not understanding.
+
+### Invariant auditing
+
+List what *must* be true for the system to behave correctly:
+
+- Ordering invariants ("X always happens before Y")
+- Uniqueness invariants ("there is exactly one of Z per user")
+- Bounds invariants ("N stays between 0 and 1000")
+- Reachability ("every state can reach terminal")
+
+Check each invariant against the failing state. The violated one is the bug's fingerprint. Property-based testing (Hypothesis, QuickCheck, fast-check) encodes this formally — generate inputs, assert invariants, let the tool find the counterexample.
+
+---
+
+## Meta-techniques
+
+### Check the boring explanations first
+
+Exotic theories are seductive; mundane causes are statistically more likely. Before anything exotic, check:
+
+- Clock skew, timezone, DST
+- Caching at any layer
+- Stale build, outdated dependency, wrong environment
+- Retry amplification
+- Off-by-one
+- Encoding (UTF-8, latin-1, BOM)
+- Feature flag state
+
+Only escalate to "compiler bug" or "kernel issue" after eliminating everything above.
+
+### Ask "but why?" one more time than feels necessary
+
+Each answer is a new question. Stop only when the next "why" lands on something immutable (physics, protocol spec, external system contract) or a human decision. "A caused B" is rarely the root — "the system allowed A to cause B" usually is.
+
+Separate:
+
+- **Trigger** — what fired it this time
+- **Cause** — what made it fireable
+- **Contributing factors** — what let it reach production
+
+A fix that only addresses the trigger leaves the gun loaded.
+
+### Rubber duck / explain it
+
+State the problem out loud, or in writing, as if teaching it. The gap in your explanation is usually the gap in your understanding. Writing a clear bug report frequently produces the answer before you hit send. Works because it forces sequential articulation of things the brain was holding as a fuzzy cloud.
+
+### Timeboxing
+
+Commit to investigating theory X for N minutes. If no progress, force a step back. Prevents sunk-cost tunneling on a wrong theory. The step back — re-reading the original symptom — is where many investigations restart correctly.
+
+### The "impossible" check
+
+When something "can't" be happening, verify the assumptions you haven't questioned:
+
+- Is the code you're reading actually running?
+- Is the config loaded in this environment?
+- Is the feature flag on for this user?
+- Is the deploy actually the version you think?
+
+Nine times out of ten, the "impossible" thing is very possible and your map was wrong.
+
+### Know when to stop digging the current hole
+
+If three hypotheses in a row die, the **framing** is probably wrong. Step back before going deeper. Re-read the original symptom. Explain the problem fresh to someone (human or rubber duck).
+
+Fresh eyes beat another hour alone.
+
+### Write it down as you go
+
+Keep a running log of hypotheses, evidence, and what's been ruled out. Future-you (two hours from now) will thank present-you. Investigators who don't write lose track and re-test things. The act of writing often surfaces the flaw in the current theory before anyone else has to read it.


### PR DESCRIPTION
This pull request introduces comprehensive documentation for the new `sherlock` skill, a disciplined workflow for investigating and diagnosing bugs, errors, and incidents. The documentation outlines the mindset, step-by-step process, and common failure modes for rigorous root cause analysis, emphasizing evidence-based investigation and clear reporting.

**New Skill Documentation: Sherlock**

* **Overview and Purpose**: Introduces the `sherlock` skill, which is designed to systematically investigate and solve complex bugs, errors, incidents, or customer-reported problems from any source (e.g., Sentry, Zendesk, GitHub issues, stack traces, or verbal descriptions). Sherlock prioritizes evidence-based diagnosis over ad-hoc debugging.

* **Investigation Workflow**:
  - Details a 13-phase investigation process, from initial orientation and evidence gathering through hypothesis formation, falsification, and proposing fixes.
  - Emphasizes disciplined practices such as checking mundane causes first, using git archaeology, and separating trigger, cause, and contributing factors.

* **Investigator Mindset and Best Practices**: Outlines the qualities and habits that distinguish effective investigators, including suspicion of one’s own conclusions, honest handling of uncertainty, and proportionate effort based on stakes.

* **Failure Modes and Anti-Patterns**: Enumerates common pitfalls in debugging (e.g., confirmation bias, anchoring,