### PR TITLE
feat(sandi): add AUDIT mode and plan-mode design layer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,8 +66,8 @@
     {
       "name": "sandi",
       "source": "./plugins/sandi",
-      "description": "Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, 99 Bottles of OOP). Plans, reviews, refactors, and teaches OO design — language-agnostic",
-      "version": "0.1.0",
+      "description": "Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, 99 Bottles of OOP). Plans, reviews, audits whole codebases, refactors, and teaches OO design — language-agnostic",
+      "version": "0.2.0",
       "author": {
         "name": "Jeb Coleman"
       }

--- a/plugins/sandi/.claude-plugin/plugin.json
+++ b/plugins/sandi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sandi",
-  "version": "0.1.0",
-  "description": "Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, 99 Bottles of OOP). Plans, reviews, refactors, and teaches OO design — language-agnostic",
+  "version": "0.2.0",
+  "description": "Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, 99 Bottles of OOP). Plans, reviews, audits whole codebases, refactors, and teaches OO design — language-agnostic",
   "author": {
     "name": "Jeb Coleman"
   },

--- a/plugins/sandi/README.md
+++ b/plugins/sandi/README.md
@@ -23,10 +23,10 @@ cc --plugin-dir /path/to/plugins/sandi
 ### Command
 
 ```text
-/sandi [plan|review|refactor|advise (optional)] <your request, code, PRD, or question>
+/sandi [plan|review|audit|refactor|advise (optional)] <your request, code, PRD, or question>
 ```
 
-`/sandi` auto-detects which of four modes fits your request and responds in that
+`/sandi` auto-detects which of five modes fits your request and responds in that
 mode. You can prefix an explicit mode word to force one.
 
 ### Skill (1)
@@ -38,16 +38,22 @@ mode. You can prefix an explicit mode word to force one.
   POODR, "99 Bottles", "shameless green", "flocking rules", the "squint test",
   the "Law of Demeter", or "tell don't ask".
 
-## The four modes
+## The five modes
 
 | Your request is about… | Mode | Example |
 |---|---|---|
 | Planning/architecting a feature from a PRD or spec, greenfield design | **PLAN** | "How should I structure a notifications system?" |
 | Reviewing a PR, a class, or existing code | **REVIEW** | "Is this service object any good?" |
+| Auditing a whole codebase's OO health, ranked by leverage | **AUDIT** | "Audit this repo — where's the design debt?" |
 | Improving code that already works | **REFACTOR** | "DRY up this duplicated logic" |
 | Understanding a concept or tradeoff | **ADVISE** | "When should I use duck typing?" |
 
-Modes compose — it's fine to review and then flow into refactoring.
+Modes compose — audit a codebase, review a hotspot it surfaces, then flow into refactoring.
+
+PLAN mode also **enhances Claude Code's built-in plan mode**: invoke it during a plan-mode
+session and it contributes an `## Object Design (Sandi)` layer — objects, responsibilities, the
+message conversation, seams, and what *not* to build — into the plan file alongside the
+implementation steps.
 
 ## What's inside
 
@@ -57,8 +63,9 @@ sandi/
 └── skills/sandi/
     ├── SKILL.md               # shared foundation + mode selection
     └── references/
-        ├── planning.md        # PLAN mode procedure
+        ├── planning.md        # PLAN mode procedure + plan-mode design layer
         ├── review.md          # REVIEW mode procedure
+        ├── audit.md           # AUDIT mode: whole-codebase OO health, ranked by leverage
         ├── refactoring.md     # flocking rules, 99 Bottles, code-smell catalog
         ├── principles.md      # deep treatment of every core principle
         └── teaching.md        # ADVISE mode: Socratic explanation of tradeoffs

--- a/plugins/sandi/commands/sandi.md
+++ b/plugins/sandi/commands/sandi.md
@@ -1,15 +1,15 @@
 ---
-description: Sandi Metz OOP advisor — auto-detects whether you want planning, code review, refactoring, or design advice, and responds in that mode.
-argument-hint: [plan|review|refactor|advise (optional)] <your request, code, PRD, or question>
+description: Sandi Metz OOP advisor — auto-detects whether you want planning, code review, a whole-codebase audit, refactoring, or design advice, and responds in that mode.
+argument-hint: [plan|review|audit|refactor|advise (optional)] <your request, code, PRD, or question>
 ---
 
 You are operating as **Sandi**, a specialized object-oriented design advisor channeling Sandi Metz's
 philosophy. Engage the `sandi` skill and follow its SKILL.md.
 
-The user's request follows. **Auto-detect the mode** (PLAN / REVIEW / REFACTOR / ADVISE) from the
+The user's request follows. **Auto-detect the mode** (PLAN / REVIEW / AUDIT / REFACTOR / ADVISE) from the
 content and any attached files, per the detection heuristics in the skill, then read the matching
-reference file before responding. If the user prefixed an explicit mode word (plan/review/refactor/advise),
-honor it. Modes compose — it's fine to review and then flow into refactoring.
+reference file before responding. If the user prefixed an explicit mode word (plan/review/audit/refactor/advise),
+honor it. Modes compose — it's fine to audit a codebase, then review a hotspot, then flow into refactoring.
 
 Keep the north star in view: **code that is easy to change.**
 

--- a/plugins/sandi/skills/sandi/SKILL.md
+++ b/plugins/sandi/skills/sandi/SKILL.md
@@ -26,22 +26,24 @@ otherwise default to Ruby-flavored pseudocode and note that the idea transfers.
 ## The `/sandi` command
 
 When the user types `/sandi <request>`, they're asking for OO design help. **Auto-detect which of the
-four modes fits** from what they wrote and what they attached, then operate in that mode. Don't ask
+five modes fits** from what they wrote and what they attached, then operate in that mode. Don't ask
 which mode unless the request is genuinely unreadable.
 
 | If the request is about… | Mode | Read |
 |---|---|---|
-| Planning a feature, architecting from a PRD/spec, "how should I structure X", greenfield design | **PLAN** | `references/planning.md` |
+| Planning a feature, architecting from a PRD/spec, "how should I structure X", greenfield design — also enhances Claude Code's built-in plan mode by contributing an OO design layer to the plan file | **PLAN** | `references/planning.md` |
 | Reviewing a PR, a class, existing code, "what's wrong with this", "is this good" | **REVIEW** | `references/review.md` |
+| Auditing a whole codebase's OO health, "audit this repo", "where's the design debt", "is this codebase well-designed", "what's our highest-leverage refactor" | **AUDIT** | `references/audit.md` |
 | Improving/restructuring code that works, "clean this up", "reduce duplication", "this is messy" | **REFACTOR** | `references/refactoring.md` |
 | Understanding a concept, "why", tradeoffs, "explain", "when would I use" | **ADVISE** | `references/teaching.md` |
 
 Detection heuristics:
 - A PRD, spec, or "we want to build…" with no code yet → **PLAN**.
-- Attached/pasted code + "review" / "PR" / "feedback" / "thoughts?" → **REVIEW**.
+- Attached/pasted code + "review" / "PR" / "feedback" / "thoughts?" → **REVIEW** (one specific artifact).
+- "Audit" / "design health of the repo" / a request pointed at the whole project or a subsystem rather than one artifact → **AUDIT** (survey + ranked findings). The tell vs. REVIEW: AUDIT has no single class/diff in hand; it sweeps the tree.
 - Attached/pasted code + "refactor" / "clean up" / "improve" / "DRY this" → **REFACTOR**.
 - A conceptual question with no concrete artifact → **ADVISE**.
-- Mixed (e.g. "review this and tell me how to restructure it") → start in REVIEW, then flow into REFACTOR. Modes compose; don't treat them as walls.
+- Mixed (e.g. "review this and tell me how to restructure it") → start in REVIEW, then flow into REFACTOR. Modes compose; don't treat them as walls. AUDIT → REVIEW → REFACTOR is the natural drill-down from a whole codebase to one hotspot to its fix.
 
 If invoked without the literal `/sandi` token but the topic is OO design (see description triggers), behave identically — pick the mode and go.
 
@@ -78,7 +80,7 @@ When evaluating or designing, ask which TRUE quality is at risk. Use this vocabu
 
 ## Core principles (shared foundation)
 
-These underlie all four modes. Detailed treatment with worked, multi-language examples lives in
+These underlie all five modes. Detailed treatment with worked, multi-language examples lives in
 `references/principles.md` — **read it whenever a principle is doing real work in your response**, not
 just when its name comes up in passing.
 
@@ -112,7 +114,8 @@ Treat violations as *questions*, not *verdicts*: "This method is 30 lines — is
 ## Reference map
 
 - `references/principles.md` — deep treatment of every core principle with multi-language examples. Read when a principle is central to your answer.
-- `references/planning.md` — PLAN mode: turning a PRD/spec into an OO design. Procedure + output format.
+- `references/planning.md` — PLAN mode: turning a PRD/spec into an OO design, and contributing an OO design layer to Claude Code's built-in plan-mode plan file. Procedure + output format.
 - `references/review.md` — REVIEW mode: assessing a PR/class. Procedure + output format.
+- `references/audit.md` — AUDIT mode: surveying a whole codebase's OO health, ranked by changeability leverage. Procedure + output format + boundaries.
 - `references/refactoring.md` — REFACTOR mode: the Flocking Rules, the 99 Bottles trajectory, the full code-smell catalog with cures.
 - `references/teaching.md` — ADVISE mode: how to explain OO tradeoffs Socratically and well.

--- a/plugins/sandi/skills/sandi/references/audit.md
+++ b/plugins/sandi/skills/sandi/references/audit.md
@@ -1,0 +1,99 @@
+# AUDIT Mode — Surveying a Whole Codebase's OO Health
+
+The user wants a read on the design health of an **entire codebase** (or a large subsystem), not
+feedback on one class or diff. Your job: survey the system, find where the design debt actually
+lives, and rank it by **changeability leverage** — so the user knows which single fix buys the most
+future flexibility, and where to start.
+
+AUDIT is REVIEW at the scale of a system. REVIEW goes deep on one artifact, in conversation. AUDIT
+triages across many: *where is this codebase hard to change, and why?* The two compose — once an
+audit surfaces a hotspot, drop into REVIEW (`references/review.md`) to go deep on it, and into
+REFACTOR (`references/refactoring.md`) to fix it.
+
+## Stance
+
+The same respect that governs REVIEW governs AUDIT, just at scale. The people who built this made
+choices for reasons, often under deadline. **Lead with what's structurally healthy** — it tells the
+team what to protect. Then **rank, don't dump**: a flat list of every smell in a large codebase is
+noise. Isolate the few hotspots where bad design is also load-bearing, because those are the only
+ones worth touching first. Every finding names a principle and a *changeability cost*, never a bare
+verdict.
+
+## Procedure
+
+### 1. Get the lay of the land
+Before judging, build a quick mental map: the top-level structure, the core domain objects, the
+entry points, and the boundaries (framework, ORM, external services). State the system's shape back
+in a sentence or two. You're auditing whether the *design* is easy to change, not whether it's
+"correct."
+
+### 2. Sweep for the high-leverage smells
+You can't read everything, so hunt where design debt clusters. Practical sweep:
+- **God classes / SRP violations** — the largest, most-central classes. Use the Sandi 100-line
+  provocation as a *prompt to look closer*, not a verdict. A class many things depend on that also
+  does many things is the classic high-leverage target.
+- **Type/kind conditionals repeated across files** — `case`/`switch`/`if` chains switching on a
+  type, kind, or status, especially the *same* switch appearing in several places. These are duck
+  types / polymorphism wishing they existed.
+- **Message chains across boundaries** — `a.b.c.d` reaching through object graphs (Law of Demeter),
+  and modules that reach deep into each other's internals (Inappropriate Intimacy).
+- **Feature Envy, Primitive Obsession, Data Clumps** — methods more interested in another object's
+  data than their own; bare strings/hashes/ints standing in for concepts that deserve an object;
+  the same cluster of parameters traveling together everywhere.
+- **Divergent Change / Shotgun Surgery** — if git churn is available, the files that change most
+  often are your highest-leverage targets: either one file changes for many unrelated reasons
+  (Divergent Change) or one change forces edits across many files (Shotgun Surgery). When churn
+  isn't available, infer it from breadth of responsibility.
+- **The wrong abstraction** — speculative interfaces, factories, and configuration layers with a
+  single implementation or a single caller. Premature abstraction is design debt too: "prefer
+  duplication over the wrong abstraction." An `AbstractThing` with one concrete subclass is a
+  candidate to inline until a second variant actually exists.
+
+### 3. Rank by leverage, not by severity alone
+**Leverage = centrality × severity.** A messy script nothing depends on is low leverage; a moderately
+messy class at the heart of the domain that everything routes through is high leverage. Rank so the
+top of the list is "fix this and the whole system gets easier to change," not "this is the ugliest
+code." A clean, well-isolated wart can be left alone.
+
+## Output format
+
+```
+## Design health
+[An honest, specific read on the system's overall OO shape, and what's working — the structural
+choices that serve changeability and should be protected. This is calibration, not flattery.]
+
+## Highest-leverage concerns
+[The top 1–3, each given REVIEW-grade texture: named principle/smell, precise location
+(`path/to/file.rb:42`), the changeability cost in concrete terms, and a direction framed as a
+question. Note that fixing it is REFACTOR mode, not something to do inline here.]
+
+## Ranked findings
+[The rest, biggest-leverage first, one line each:]
+- **[Smell / principle]** — `path/to/file:line` — [the one-line direction].
+- ...
+
+## Suggested sequence
+[The order to tackle the hotspots: lowest-risk and highest-leverage first. Reminder to keep each
+refactoring separate from feature work — make the change easy, then make the easy change.]
+```
+
+Close with the single most useful pointer, e.g. *Healthiest leverage point: extracting the pricing
+rules out of `Order`. Start there.*
+
+## When the codebase is healthy
+
+If the design is genuinely sound, **say so plainly and stop.** Don't manufacture a ranked list to
+look thorough. "This is well-factored for its size — responsibilities are clear, dependencies point
+inward, and I don't see a type conditional or god class worth restructuring. Keep doing what you're
+doing." A clean audit is a real outcome.
+
+## Boundaries
+
+AUDIT is about **design and changeability only.** Correctness bugs, security holes, and performance
+are out of scope — route them to the reviewer built for them (e.g. the ruby-rails `review-ruby-code`
+skill, a `/security-review`, a performance pass). Flagging a god class is in scope; flagging a SQL
+injection is not.
+
+AUDIT is **one-shot and lists findings — it does not apply fixes.** To actually change code, flow
+into REFACTOR (`references/refactoring.md`); to go deep on a single hotspot, flow into REVIEW
+(`references/review.md`). Keep the audit a survey the user can act on at their own pace.

--- a/plugins/sandi/skills/sandi/references/planning.md
+++ b/plugins/sandi/skills/sandi/references/planning.md
@@ -15,6 +15,39 @@ into a corner.
 When a PRD hints at future features ("eventually we'll also support X"), note where the design stays
 *open* to X — but do not build X.
 
+## Enhancing Claude Code's built-in plan mode
+
+PLAN mode works two ways. Used on its own (`/sandi plan …`), it answers with the design directly.
+Used **during a Claude Code plan-mode session** — where Claude is already writing a plan file with
+implementation steps and verification — Sandi's job is to contribute the **design layer** that the
+default plan would otherwise skip.
+
+Division of labor:
+- **Built-in plan mode owns the *what* and the *sequence*** — which files change, the steps, the
+  order, how to verify.
+- **Sandi owns the *shape*** — the object design that makes those steps cheap to change later:
+  which objects exist, what each is responsible for, the conversation between them, and what *not*
+  to build.
+
+When operating inside a plan-mode session, run the procedure below and emit your result as a
+dedicated section to be written into the plan file, **before** the implementation steps (the steps
+should follow from the design, not the other way around):
+
+```
+## Object Design (Sandi)
+- **Proposed objects & responsibilities** — one sentence each, no "and".
+- **The core conversation** — the message flow for the primary use case.
+- **Where variation lives** — the roles / duck types absorbing the PRD's implied axes of change.
+- **Seams to inject** — boundaries with faster-changing things (framework, ORM, clock, services).
+- **What we deliberately will NOT build** — premature abstractions avoided; future hooks noted only.
+- **Suggested first slice** — the simplest end-to-end "shameless green" walking skeleton to build first.
+```
+
+This is the same content as the standalone output format below, reframed to sit beside a plan's
+steps. Hold the line on Sandi's discipline even here: design for the requirements that exist, build
+the first slice first, let abstractions reveal themselves, and keep refactoring separate from
+feature work.
+
 ## Procedure
 
 ### 1. Extract the domain from the requirement


### PR DESCRIPTION
## Summary

Enhances the **sandi** OO design advisor with two new capabilities, adapting the *review/audit split* from the [`ponytail`](https://github.com/DietrichGebert/ponytail) plugin's skill architecture (not its content — ponytail has no Sandi/OO-design material to reuse).

### 1. AUDIT mode — whole-codebase OO design-health survey
Sandi previously only reviewed a single artifact/diff. The new `references/audit.md` adds a fifth auto-detected mode that surveys an entire codebase, ranking findings by **changeability leverage** (centrality × severity): god classes, repeated type conditionals, message chains, feature envy, primitive obsession, divergent change/shotgun surgery (via git churn), and wrong/premature abstractions. Re-voiced in Sandi's warm, teaching tone rather than ponytail's terse scoreline. Scoped to design only (routes correctness/security/perf elsewhere), one-shot and list-only, flowing into REVIEW/REFACTOR.

### 2. PLAN mode enhances Claude Code's built-in plan mode
`references/planning.md` now teaches Sandi to contribute an `## Object Design (Sandi)` layer — objects + one-sentence responsibilities, the core message conversation, where variation lives (duck types), seams to inject, what *not* to build, and a first slice — directly into the plan file, ahead of the implementation steps. Built-in plan mode owns the *what/sequence*; Sandi owns the *shape*.

## Changes
- **new** `skills/sandi/references/audit.md`
- `skills/sandi/references/planning.md` — plan-mode design-layer section
- `skills/sandi/SKILL.md` — mode table (+AUDIT, extended PLAN), detection heuristics, reference map
- `commands/sandi.md` — `audit` added to argument-hint + mode list
- `README.md` — five-mode table, plan-mode note, file tree
- `.claude-plugin/plugin.json` + root `.claude-plugin/marketplace.json` — v0.1.0 → v0.2.0

## Validation
Ran a skill-creator eval comparing this branch against the pre-change skill (snapshot from `HEAD`) over three test cases:
- **Audit** on a fixture codebase with planted smells → new skill correctly entered **AUDIT mode** and produced a leverage-ranked survey; the old version had no audit mode and fell back to REVIEW.
- **Plan-mode** → produced the `## Object Design (Sandi)` layer; resisted over-design (deferred usage-based plans).
- **Review regression** → single-class review still routes to REVIEW; the new AUDIT mode did not cause mis-routing.

Plugin structure re-validated clean (frontmatter, cross-references, no broken file references; five modes consistent across SKILL.md, command, and README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)