### PR TITLE
feat(sandi,fowler): add installable GitHub Actions PR-review workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,8 +66,8 @@
     {
       "name": "sandi",
       "source": "./plugins/sandi",
-      "description": "Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, 99 Bottles of OOP). Plans, reviews, audits whole codebases, refactors, and teaches OO design — language-agnostic",
-      "version": "0.2.0",
+      "description": "Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, 99 Bottles of OOP). Plans, reviews, audits whole codebases, refactors, and teaches OO design — language-agnostic. Includes an installable GitHub Actions PR-review workflow",
+      "version": "0.3.0",
       "author": {
         "name": "Jeb Coleman"
       }
@@ -75,8 +75,8 @@
     {
       "name": "fowler",
       "source": "./plugins/fowler",
-      "description": "Refactoring advisor grounded in Martin Fowler's catalog (Refactoring, 2nd ed.). Diagnoses code smells, applies refactorings step-by-step with tests between steps, and teaches when and why to use each technique — language-agnostic",
-      "version": "0.1.0",
+      "description": "Refactoring advisor grounded in Martin Fowler's catalog (Refactoring, 2nd ed.). Diagnoses code smells, applies refactorings step-by-step with tests between steps, and teaches when and why to use each technique — language-agnostic. Includes an installable GitHub Actions PR-review workflow",
+      "version": "0.2.0",
       "author": {
         "name": "Jeb Coleman"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ ai-context/
 │   ├── js-ts/           # JavaScript/TypeScript (3 skills, 1 command)
 │   ├── devops/          # DevOps & infrastructure (3 skills, 1 command)
 │   ├── general/         # General utilities (1 skill)
-│   ├── sandi/           # Sandi Metz OO design advisor (1 skill, 1 command)
-│   └── fowler/          # Martin Fowler refactoring advisor (1 skill, 1 command)
+│   ├── sandi/           # Sandi Metz OO design advisor (1 skill, 2 commands, 1 workflow template)
+│   └── fowler/          # Martin Fowler refactoring advisor (1 skill, 2 commands, 1 workflow template)
 └── tools/               # Helper scripts
 ```
 
@@ -32,7 +32,8 @@ plugins/<name>/
 │   └── plugin.json      # Plugin manifest
 ├── skills/              # SKILL.md files with references/
 ├── commands/            # Slash command definitions
-└── agents/              # Agent configurations
+├── agents/              # Agent configurations
+└── templates/           # Installable file templates (e.g. GitHub workflows)
 ```
 
 ## Key Plugins
@@ -60,11 +61,11 @@ DevOps toolkit with GitHub Actions, Kamal deployment, and Tailscale skills.
 
 ### sandi
 
-Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, *99 Bottles of OOP*). The `/sandi` command auto-detects whether you want planning, code review, refactoring, or design advice. Language-agnostic.
+Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, *99 Bottles of OOP*). The `/sandi` command auto-detects whether you want planning, code review, refactoring, or design advice. Language-agnostic. `/sandi:install-review` installs a GitHub Actions workflow (from `templates/sandi-review.yml`) that runs a Sandi review on every PR via claude-code-action.
 
 ### fowler
 
-Refactoring advisor grounded in Martin Fowler's *Refactoring* (2nd edition) catalog. The `/fowler` command auto-detects whether you want a smell diagnosis, a guided step-by-step refactoring, or advice on when/why to use a technique. Language-agnostic.
+Refactoring advisor grounded in Martin Fowler's *Refactoring* (2nd edition) catalog. The `/fowler` command auto-detects whether you want a smell diagnosis, a guided step-by-step refactoring, or advice on when/why to use a technique. Language-agnostic. `/fowler:install-review` installs a GitHub Actions workflow (from `templates/fowler-review.yml`) that runs a refactoring review on every PR via claude-code-action.
 
 ## Installation
 

--- a/plugins/fowler/.claude-plugin/plugin.json
+++ b/plugins/fowler/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "fowler",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Refactoring advisor grounded in Martin Fowler's catalog (Refactoring, 2nd ed.). Diagnoses code smells, applies refactorings step-by-step with tests between steps, and teaches when and why to use each technique — language-agnostic",
   "author": {
     "name": "Jeb Coleman"
   },
-  "commands": ["./commands/fowler.md"],
+  "commands": ["./commands/fowler.md", "./commands/install-review.md"],
   "skills": ["./skills/fowler"]
 }

--- a/plugins/fowler/README.md
+++ b/plugins/fowler/README.md
@@ -36,6 +36,13 @@ The mode keyword is optional — the skill auto-detects intent:
 /fowler when should I use Split Phase?             # advice/teaching
 ```
 
+```text
+/fowler:install-review [path glob(s) (optional)]
+```
+
+`/fowler:install-review` installs an automated PR-review GitHub workflow into
+the current repository (see below).
+
 ### Skill trigger
 
 The skill also activates without the command whenever you ask to refactor,
@@ -50,6 +57,122 @@ name, or wrestle with code that's hard to read or change.
 | **REFACTOR** | Applies a refactoring following its catalog mechanics — one small step at a time, tests between steps, never mixing behavior change with structure change |
 | **ADVISE** | Explains and compares techniques: motivation, trade-offs, inverses, and when *not* to refactor |
 
+## Automated PR reviews (GitHub Actions)
+
+The plugin ships a generic `fowler-review.yml` workflow template that runs a
+refactoring review on every PR via [claude-code-action](https://github.com/anthropics/claude-code-action).
+Install it into any GitHub repo with:
+
+```text
+/fowler:install-review           # review all changed files in each PR
+/fowler:install-review app/** lib/**   # scope the review to specific paths
+```
+
+How it works:
+
+- Fires automatically when a PR is opened or reopened; comment `/fowler` on a
+  PR (owners/members/collaborators only) to request a re-review.
+- Installs the `fowler` plugin from this marketplace into the CI runner, so the
+  target repo needs no vendored skill files — updates to the plugin flow
+  through automatically.
+- Delivers the review like a human reviewer — in the tone of a teacher/coach,
+  explaining why each smell hurts: inline comments that name each smell by its
+  catalog name and prescribe the curing refactoring (with one-click
+  ```suggestion blocks where the fix is small), plus a single summary comment
+  with a prioritized refactoring order.
+
+### Requirements
+
+- A repository hosted on **GitHub** (the workflow uses GitHub Actions and the
+  `gh` CLI).
+- **Claude Code** installed locally with this plugin installed (to run the
+  installer command; the workflow file itself is plain YAML you could also
+  copy by hand from `templates/fowler-review.yml`).
+- The **`gh` CLI** authenticated against the repo (`gh auth login`) — the
+  installer uses it to check/set the repo secret.
+- A **Claude subscription (Pro/Max) or Claude Console account** to generate an
+  OAuth token — the CI review runs on your Claude account.
+- **Admin access** to the repo (setting Actions secrets requires it).
+
+### First-time setup
+
+```bash
+# 1. In Claude Code, install the plugin (once per machine)
+/plugin marketplace add el-feo/ai-context
+/plugin install fowler@jebs-dev-tools
+
+# 2. From the repo you want reviewed, run the installer
+/fowler:install-review             # or: /fowler:install-review app/** lib/**
+
+# 3. Create the token and store it as a repo secret
+#    (the installer checks for this and walks you through it if missing)
+claude setup-token
+gh secret set CLAUDE_CODE_OAUTH_TOKEN
+
+# 4. Commit the workflow and open a PR — the first review fires automatically
+git add .github/workflows/fowler-review.yml && git commit -m "ci: add Fowler refactoring review"
+```
+
+### Using Amazon Bedrock instead
+
+The template authenticates against Anthropic's hosted API with an OAuth token.
+To run the review through Amazon Bedrock — billing via AWS, no Claude
+subscription or `CLAUDE_CODE_OAUTH_TOKEN` needed — swap the auth wiring; the
+plugin install, security gating, and review prompt all carry over unchanged.
+
+Two things differ:
+
+- **AWS auth via GitHub OIDC** (recommended — no long-lived AWS keys): the
+  workflow's existing `id-token: write` permission lets
+  `aws-actions/configure-aws-credentials` assume an IAM role.
+- **Bring your own GitHub App**: the Anthropic-hosted flow gets its GitHub
+  credentials from an OIDC exchange with Anthropic's backend. With Bedrock
+  there is no Anthropic backend, so you must create a GitHub App and mint a
+  token with `actions/create-github-app-token`, passing it as both the
+  `github_token` input and the `GH_TOKEN` env var.
+
+Replace the `claude-code-action` step (and its `claude_code_oauth_token`
+input) with:
+
+```yaml
+- name: Generate GitHub App token
+  id: app-token
+  uses: actions/create-github-app-token@v2
+  with:
+    app-id: ${{ secrets.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+- name: Configure AWS credentials (OIDC)
+  uses: aws-actions/configure-aws-credentials@v4
+  with:
+    role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+    aws-region: us-west-2
+
+- uses: anthropics/claude-code-action@v1
+  env:
+    GH_TOKEN: ${{ steps.app-token.outputs.token }}
+  with:
+    github_token: ${{ steps.app-token.outputs.token }}
+    use_bedrock: "true"
+    # plugin_marketplaces, plugins, prompt, use_sticky_comment: unchanged
+    claude_args: |
+      --model us.anthropic.claude-sonnet-5-v1:0   # Bedrock model ID, not the API name
+      # --allowedTools and --max-turns: unchanged
+```
+
+One-time AWS setup:
+
+1. Create an IAM **OIDC identity provider** for
+   `token.actions.githubusercontent.com`.
+2. Create an **IAM role** trusting that provider, scoped to your repo
+   (`repo:org/repo:*` in the `sub` condition), with `bedrock:InvokeModel` and
+   `bedrock:InvokeModelWithResponseStream` on the Claude model ARNs.
+3. Grant **model access in the Bedrock console** — in every region the
+   cross-region inference profile spans, not just the one you call.
+
+See the [claude-code-action cloud providers docs](https://github.com/anthropics/claude-code-action/blob/main/docs/cloud-providers.md)
+for details (Google Vertex AI follows the same pattern).
+
 ## What's inside
 
 ```text
@@ -57,7 +180,10 @@ fowler/
 ├── .claude-plugin/
 │   └── plugin.json              # Plugin manifest
 ├── commands/
-│   └── fowler.md                # /fowler — thin wrapper that engages the skill
+│   ├── fowler.md                # /fowler — thin wrapper that engages the skill
+│   └── install-review.md        # /fowler:install-review — install the PR-review workflow
+├── templates/
+│   └── fowler-review.yml        # generic GitHub Actions workflow template
 └── skills/
     └── fowler/
         ├── SKILL.md             # Modes, discipline, and catalog index

--- a/plugins/fowler/commands/install-review.md
+++ b/plugins/fowler/commands/install-review.md
@@ -1,0 +1,50 @@
+---
+description: Install the Fowler refactoring PR-review GitHub workflow into the current repository.
+argument-hint: [path glob(s) to scope the review to (optional), e.g. app/** lib/**]
+---
+
+Install the Fowler refactoring review workflow into this repository. The
+workflow runs `claude-code-action` on every opened/reopened PR (and on
+`/fowler` PR comments), installs the `fowler` plugin from the jebs-dev-tools
+marketplace into the CI runner, and delivers a code-smell diagnosis as inline
+PR comments plus one summary comment with a prioritized refactoring order.
+
+The generic template lives at `${CLAUDE_PLUGIN_ROOT}/templates/fowler-review.yml`.
+
+Follow these steps:
+
+1. **Verify the repo.** Confirm the current directory is a git repository with
+   a GitHub remote (`git remote -v`). If not, stop and explain that the
+   workflow only works on GitHub-hosted repos.
+
+2. **Check for an existing install.** If `.github/workflows/fowler-review.yml`
+   already exists, show the user how it differs from the template and ask
+   before overwriting.
+
+3. **Copy the template** to `.github/workflows/fowler-review.yml` (create the
+   directory if needed).
+
+4. **Scope the review (optional).** If the user passed path globs as arguments,
+   or asks to limit the review to part of the codebase:
+   - Add a `paths:` filter under the `pull_request` trigger with those globs
+     (replace the commented example).
+   - Update the `Scope:` paragraph in the prompt to say the review covers ONLY
+     changed files matching those paths and ignores changes elsewhere.
+
+   If no scope was given, leave the template as-is — it reviews all changed
+   files in the PR.
+
+5. **Verify the secret.** Run `gh secret list` and check for
+   `CLAUDE_CODE_OAUTH_TOKEN`. If it's missing, tell the user to create one:
+
+   ```bash
+   claude setup-token   # generates an OAuth token (requires a Claude subscription)
+   gh secret set CLAUDE_CODE_OAUTH_TOKEN
+   ```
+
+6. **Summarize.** Tell the user: the workflow file installed, how it triggers
+   (auto on PR open/reopen; `/fowler` comment from an owner/member/collaborator
+   for a re-review), any scoping applied, and whether the secret is in place.
+   Offer to commit the workflow file — but do not commit without their say-so.
+
+$ARGUMENTS

--- a/plugins/fowler/templates/fowler-review.yml
+++ b/plugins/fowler/templates/fowler-review.yml
@@ -1,0 +1,109 @@
+name: Fowler Refactoring Review
+
+on:
+  # First review: fires automatically when a PR is opened or reopened.
+  pull_request:
+    types: [opened, reopened]
+    # To limit automatic reviews to part of the codebase, add a paths filter:
+    # paths:
+    #   - "app/**"
+    #   - "lib/**"
+  # Re-review on demand: comment "/fowler" on the PR to request another pass.
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write # required by claude-code-action to fetch an OIDC token
+  actions: read # lets claude-code-action read CI status checks
+
+jobs:
+  fowler-review:
+    # Run on PR open/reopen, OR on a PR comment starting with "/fowler".
+    # The issue_comment event ALWAYS runs with repo secrets and checks out the
+    # PR head (attacker-controlled), so it must be gated on commenter trust to
+    # avoid a pwn-request: only repo owners/members/collaborators can trigger
+    # it. (issue_comment also fires on plain issues, so we require .pull_request.)
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/fowler') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history so Claude can diff against the base branch
+          # On pull_request use the PR head; on issue_comment there's no
+          # pull_request payload, so fall back to the PR head ref by number.
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
+
+      - uses: anthropics/claude-code-action@v1
+        # `gh` CLI calls from the review agent (gh pr diff / gh pr comment)
+        # need an authenticated token in the environment — the action's own
+        # token wiring only covers its MCP servers, not Bash subprocesses.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Surface the full agent transcript in the run log so denied tool
+          # calls and errors are diagnosable (the default hides everything).
+          show_full_output: true
+
+          # Install the `fowler` plugin from the jebs-dev-tools marketplace
+          # (public repo el-feo/ai-context) into the fresh CI runner.
+          plugin_marketplaces: |
+            https://github.com/el-feo/ai-context.git
+          plugins: |
+            fowler@jebs-dev-tools
+
+          # Deliver a human-style review: inline comments anchored to the diff,
+          # plus one non-redundant summary. use_sticky_comment stays false so the
+          # inline notes and the summary are separate comments (no single blob).
+          use_sticky_comment: false
+          prompt: |
+            Use the /fowler:fowler skill to review this pull request through
+            the lens of Martin Fowler's Refactoring catalog (2nd edition), then
+            deliver it the way a thoughtful human reviewer would — NOT as one
+            long essay in a single comment.
+
+            Tone: you are a teacher and coach, not a gatekeeper. Assume the
+            author is capable but may not have met the smell or technique
+            before. For each finding, teach the underlying idea so they can
+            spot it themselves next time — explain WHY the smell hurts, not
+            just what to change. Be encouraging and collegial, never scolding;
+            when the diff does something well, say so briefly.
+
+            Scope: review the files changed in this pull request. Anchor
+            everything to the diff against the base branch.
+
+            How to deliver the review:
+            1. For each concrete finding, leave an INLINE comment on the exact
+               line(s) it concerns using the
+               mcp__github_inline_comment__create_inline_comment tool. Name the
+               code smell by its catalog name, explain why it makes the code
+               harder to read or change, and prescribe the catalog refactoring
+               that cures it — including the first mechanical step the author
+               would take.
+            2. When the fix is a small, exact replacement of changed lines,
+               include a GitHub ```suggestion block so the author can commit it
+               in one click. Only attach suggestions to lines present in the diff.
+            3. Keep each inline comment to its one line/region. Do not restate
+               the same point across multiple comments.
+            4. Finally, post exactly ONE summary comment with `gh pr comment`.
+               It must NOT repeat the inline findings. Use it only to tie things
+               together: cross-cutting smells, a prioritized refactoring order
+               (highest payoff first), and — where honest — where refactoring
+               is NOT worth it right now. If there is nothing broader to say
+               than the inline comments already cover, keep the summary to a
+               single sentence.
+          # The allowlist must cover everything the prompt instructs: `Skill`
+          # to invoke /fowler:fowler (denied tools fail silently in CI), and
+          # git/gh diff commands so the review can actually see the PR's diff.
+          claude_args: |
+            --model claude-sonnet-5
+            --allowedTools "Skill,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git status:*),Bash(git branch:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Read,Grep,Glob"
+            --max-turns 100

--- a/plugins/sandi/.claude-plugin/plugin.json
+++ b/plugins/sandi/.claude-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "sandi",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, 99 Bottles of OOP). Plans, reviews, audits whole codebases, refactors, and teaches OO design — language-agnostic",
   "author": {
     "name": "Jeb Coleman"
   },
   "commands": [
-    "./commands/sandi.md"
+    "./commands/sandi.md",
+    "./commands/install-review.md"
   ],
   "skills": [
     "./skills/sandi"

--- a/plugins/sandi/README.md
+++ b/plugins/sandi/README.md
@@ -29,6 +29,13 @@ cc --plugin-dir /path/to/plugins/sandi
 `/sandi` auto-detects which of five modes fits your request and responds in that
 mode. You can prefix an explicit mode word to force one.
 
+```text
+/sandi:install-review [path glob(s) (optional)]
+```
+
+`/sandi:install-review` installs an automated PR-review GitHub workflow into the
+current repository (see below).
+
 ### Skill (1)
 
 - **sandi** — Triggers on the `/sandi` command, or whenever you ask about
@@ -55,11 +62,128 @@ session and it contributes an `## Object Design (Sandi)` layer — objects, resp
 message conversation, seams, and what *not* to build — into the plan file alongside the
 implementation steps.
 
+## Automated PR reviews (GitHub Actions)
+
+The plugin ships a generic `sandi-review.yml` workflow template that runs a
+Sandi review on every PR via [claude-code-action](https://github.com/anthropics/claude-code-action).
+Install it into any GitHub repo with:
+
+```text
+/sandi:install-review            # review all changed files in each PR
+/sandi:install-review app/** lib/**   # scope the review to specific paths
+```
+
+How it works:
+
+- Fires automatically when a PR is opened or reopened; comment `/sandi` on a PR
+  (owners/members/collaborators only) to request a re-review.
+- Installs the `sandi` plugin from this marketplace into the CI runner, so the
+  target repo needs no vendored skill files — updates to the plugin flow
+  through automatically.
+- Delivers the review like a human reviewer — in the tone of a teacher/coach,
+  explaining the why behind each finding: inline comments anchored to the diff
+  (with one-click ```suggestion blocks where the fix is small), plus a single
+  summary comment covering cross-cutting themes and priorities.
+
+### Requirements
+
+- A repository hosted on **GitHub** (the workflow uses GitHub Actions and the
+  `gh` CLI).
+- **Claude Code** installed locally with this plugin installed (to run the
+  installer command; the workflow file itself is plain YAML you could also
+  copy by hand from `templates/sandi-review.yml`).
+- The **`gh` CLI** authenticated against the repo (`gh auth login`) — the
+  installer uses it to check/set the repo secret.
+- A **Claude subscription (Pro/Max) or Claude Console account** to generate an
+  OAuth token — the CI review runs on your Claude account.
+- **Admin access** to the repo (setting Actions secrets requires it).
+
+### First-time setup
+
+```bash
+# 1. In Claude Code, install the plugin (once per machine)
+/plugin marketplace add el-feo/ai-context
+/plugin install sandi@jebs-dev-tools
+
+# 2. From the repo you want reviewed, run the installer
+/sandi:install-review              # or: /sandi:install-review app/** lib/**
+
+# 3. Create the token and store it as a repo secret
+#    (the installer checks for this and walks you through it if missing)
+claude setup-token
+gh secret set CLAUDE_CODE_OAUTH_TOKEN
+
+# 4. Commit the workflow and open a PR — the first review fires automatically
+git add .github/workflows/sandi-review.yml && git commit -m "ci: add Sandi Metz PR review"
+```
+
+### Using Amazon Bedrock instead
+
+The template authenticates against Anthropic's hosted API with an OAuth token.
+To run the review through Amazon Bedrock — billing via AWS, no Claude
+subscription or `CLAUDE_CODE_OAUTH_TOKEN` needed — swap the auth wiring; the
+plugin install, security gating, and review prompt all carry over unchanged.
+
+Two things differ:
+
+- **AWS auth via GitHub OIDC** (recommended — no long-lived AWS keys): the
+  workflow's existing `id-token: write` permission lets
+  `aws-actions/configure-aws-credentials` assume an IAM role.
+- **Bring your own GitHub App**: the Anthropic-hosted flow gets its GitHub
+  credentials from an OIDC exchange with Anthropic's backend. With Bedrock
+  there is no Anthropic backend, so you must create a GitHub App and mint a
+  token with `actions/create-github-app-token`, passing it as both the
+  `github_token` input and the `GH_TOKEN` env var.
+
+Replace the `claude-code-action` step (and its `claude_code_oauth_token`
+input) with:
+
+```yaml
+- name: Generate GitHub App token
+  id: app-token
+  uses: actions/create-github-app-token@v2
+  with:
+    app-id: ${{ secrets.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+- name: Configure AWS credentials (OIDC)
+  uses: aws-actions/configure-aws-credentials@v4
+  with:
+    role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+    aws-region: us-west-2
+
+- uses: anthropics/claude-code-action@v1
+  env:
+    GH_TOKEN: ${{ steps.app-token.outputs.token }}
+  with:
+    github_token: ${{ steps.app-token.outputs.token }}
+    use_bedrock: "true"
+    # plugin_marketplaces, plugins, prompt, use_sticky_comment: unchanged
+    claude_args: |
+      --model us.anthropic.claude-sonnet-5-v1:0   # Bedrock model ID, not the API name
+      # --allowedTools and --max-turns: unchanged
+```
+
+One-time AWS setup:
+
+1. Create an IAM **OIDC identity provider** for
+   `token.actions.githubusercontent.com`.
+2. Create an **IAM role** trusting that provider, scoped to your repo
+   (`repo:org/repo:*` in the `sub` condition), with `bedrock:InvokeModel` and
+   `bedrock:InvokeModelWithResponseStream` on the Claude model ARNs.
+3. Grant **model access in the Bedrock console** — in every region the
+   cross-region inference profile spans, not just the one you call.
+
+See the [claude-code-action cloud providers docs](https://github.com/anthropics/claude-code-action/blob/main/docs/cloud-providers.md)
+for details (Google Vertex AI follows the same pattern).
+
 ## What's inside
 
 ```text
 sandi/
 ├── commands/sandi.md          # /sandi slash command
+├── commands/install-review.md # /sandi:install-review — install the PR-review workflow
+├── templates/sandi-review.yml # generic GitHub Actions workflow template
 └── skills/sandi/
     ├── SKILL.md               # shared foundation + mode selection
     └── references/

--- a/plugins/sandi/commands/install-review.md
+++ b/plugins/sandi/commands/install-review.md
@@ -1,0 +1,50 @@
+---
+description: Install the Sandi Metz automated PR-review GitHub workflow into the current repository.
+argument-hint: [path glob(s) to scope the review to (optional), e.g. app/** lib/**]
+---
+
+Install the Sandi Metz automated PR review workflow into this repository. The
+workflow runs `claude-code-action` on every opened/reopened PR (and on `/sandi`
+PR comments), installs the `sandi` plugin from the jebs-dev-tools marketplace
+into the CI runner, and delivers the review as inline PR comments plus one
+summary comment.
+
+The generic template lives at `${CLAUDE_PLUGIN_ROOT}/templates/sandi-review.yml`.
+
+Follow these steps:
+
+1. **Verify the repo.** Confirm the current directory is a git repository with
+   a GitHub remote (`git remote -v`). If not, stop and explain that the
+   workflow only works on GitHub-hosted repos.
+
+2. **Check for an existing install.** If `.github/workflows/sandi-review.yml`
+   already exists, show the user how it differs from the template and ask
+   before overwriting.
+
+3. **Copy the template** to `.github/workflows/sandi-review.yml` (create the
+   directory if needed).
+
+4. **Scope the review (optional).** If the user passed path globs as arguments,
+   or asks to limit the review to part of the codebase:
+   - Add a `paths:` filter under the `pull_request` trigger with those globs
+     (replace the commented example).
+   - Update the `Scope:` paragraph in the prompt to say the review covers ONLY
+     changed files matching those paths and ignores changes elsewhere.
+
+   If no scope was given, leave the template as-is — it reviews all changed
+   files in the PR.
+
+5. **Verify the secret.** Run `gh secret list` and check for
+   `CLAUDE_CODE_OAUTH_TOKEN`. If it's missing, tell the user to create one:
+
+   ```bash
+   claude setup-token   # generates an OAuth token (requires a Claude subscription)
+   gh secret set CLAUDE_CODE_OAUTH_TOKEN
+   ```
+
+6. **Summarize.** Tell the user: the workflow file installed, how it triggers
+   (auto on PR open/reopen; `/sandi` comment from an owner/member/collaborator
+   for a re-review), any scoping applied, and whether the secret is in place.
+   Offer to commit the workflow file — but do not commit without their say-so.
+
+$ARGUMENTS

--- a/plugins/sandi/templates/sandi-review.yml
+++ b/plugins/sandi/templates/sandi-review.yml
@@ -1,0 +1,105 @@
+name: Sandi Metz Review
+
+on:
+  # First review: fires automatically when a PR is opened or reopened.
+  pull_request:
+    types: [opened, reopened]
+    # To limit automatic reviews to part of the codebase, add a paths filter:
+    # paths:
+    #   - "app/**"
+    #   - "lib/**"
+  # Re-review on demand: comment "/sandi" on the PR to request another pass.
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write # required by claude-code-action to fetch an OIDC token
+  actions: read # lets claude-code-action read CI status checks
+
+jobs:
+  sandi-review:
+    # Run on PR open/reopen, OR on a PR comment starting with "/sandi".
+    # The issue_comment event ALWAYS runs with repo secrets and checks out the
+    # PR head (attacker-controlled), so it must be gated on commenter trust to
+    # avoid a pwn-request: only repo owners/members/collaborators can trigger
+    # it. (issue_comment also fires on plain issues, so we require .pull_request.)
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/sandi') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history so Claude can diff against the base branch
+          # On pull_request use the PR head; on issue_comment there's no
+          # pull_request payload, so fall back to the PR head ref by number.
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
+
+      - uses: anthropics/claude-code-action@v1
+        # `gh` CLI calls from the review agent (gh pr diff / gh pr comment)
+        # need an authenticated token in the environment — the action's own
+        # token wiring only covers its MCP servers, not Bash subprocesses.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Surface the full agent transcript in the run log so denied tool
+          # calls and errors are diagnosable (the default hides everything).
+          show_full_output: true
+
+          # Install the `sandi` plugin from the jebs-dev-tools marketplace
+          # (public repo el-feo/ai-context) into the fresh CI runner.
+          plugin_marketplaces: |
+            https://github.com/el-feo/ai-context.git
+          plugins: |
+            sandi@jebs-dev-tools
+
+          # Deliver a human-style review: inline comments anchored to the diff,
+          # plus one non-redundant summary. use_sticky_comment stays false so the
+          # inline notes and the summary are separate comments (no single blob).
+          use_sticky_comment: false
+          prompt: |
+            Use the /sandi:sandi skill to perform an object-oriented design
+            review of this pull request, then deliver it the way a thoughtful
+            human reviewer would — NOT as one long essay in a single comment.
+
+            Tone: you are a teacher and coach, not a gatekeeper. Assume the
+            author is capable but may not have met the principle at play yet.
+            For each finding, teach the underlying idea so they can apply it
+            themselves next time — explain WHY, not just what to change. Be
+            encouraging and collegial, never scolding; when the diff does
+            something well, say so briefly.
+
+            Scope: review the files changed in this pull request. Anchor
+            everything to the diff against the base branch.
+
+            How to deliver the review:
+            1. For each concrete finding, leave an INLINE comment on the exact
+               line(s) it concerns using the
+               mcp__github_inline_comment__create_inline_comment tool. Write it
+               in Sandi's voice: name the smell, explain why it raises the cost
+               of change, and propose the fix.
+            2. When the fix is a small, exact replacement of changed lines,
+               include a GitHub ```suggestion block so the author can commit it
+               in one click. Only attach suggestions to lines present in the diff.
+            3. Keep each inline comment to its one line/region. Do not restate
+               the same point across multiple comments.
+            4. Finally, post exactly ONE summary comment with `gh pr comment`.
+               It must NOT repeat the inline findings. Use it only to tie things
+               together: cross-cutting themes, the root design pressure, and a
+               prioritized order of what to fix first. If there is nothing
+               broader to say than the inline comments already cover, keep the
+               summary to a single sentence.
+          # The allowlist must cover everything the prompt instructs: `Skill`
+          # to invoke /sandi:sandi (denied tools fail silently in CI), and
+          # git/gh diff commands so the review can actually see the PR's diff.
+          claude_args: |
+            --model claude-sonnet-5
+            --allowedTools "Skill,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git status:*),Bash(git branch:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Read,Grep,Glob"
+            --max-turns 100


### PR DESCRIPTION
## Summary

Packages the Sandi Metz PR-review GitHub workflow (proven in a downstream repo) as a generic, installable template in the `sandi` plugin, and adds a matching Fowler refactoring-review workflow using the same approach.

- **Workflow templates** (`plugins/{sandi,fowler}/templates/*-review.yml`): generic `claude-code-action` workflows that fire on PR open/reopen and on `/sandi` / `/fowler` PR comments (gated on owner/member/collaborator to prevent pwn-requests). The plugin is installed from this marketplace into the CI runner at review time, so consuming repos vendor nothing and pick up plugin updates automatically. Reviews are delivered in a teacher/coach tone as inline diff-anchored comments (with one-click suggestion blocks) plus a single non-redundant summary comment.
- **Installer commands**: `/sandi:install-review` and `/fowler:install-review` copy the template into any repo's `.github/workflows/`, optionally scope it to path globs (e.g. `app/** lib/**`), and check for the `CLAUDE_CODE_OAUTH_TOKEN` secret, walking the user through `claude setup-token` if missing.
- **Docs**: both READMEs gain Requirements, First-time setup, and a "Using Amazon Bedrock instead" section (GitHub OIDC → IAM role assumption, bring-your-own GitHub App token). Root CLAUDE.md updated.
- **Versions**: sandi 0.2.0 → 0.3.0, fowler 0.1.0 → 0.2.0, mirrored in `marketplace.json`.

## Notes

- The templates reference this marketplace by URL, so the workflows only function in other repos once this lands on `main`.
- Workflow YAML and all JSON validated; the template's security gating, checkout-ref fallback, and tool allowlist are carried over unchanged from the battle-tested original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)