### PR TITLE
fix(sandi,fowler): harden PR-review workflow templates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins for developer productivity",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -67,7 +67,7 @@
       "name": "sandi",
       "source": "./plugins/sandi",
       "description": "Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, 99 Bottles of OOP). Plans, reviews, audits whole codebases, refactors, and teaches OO design — language-agnostic. Includes an installable GitHub Actions PR-review workflow",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "Jeb Coleman"
       }
@@ -76,7 +76,7 @@
       "name": "fowler",
       "source": "./plugins/fowler",
       "description": "Refactoring advisor grounded in Martin Fowler's catalog (Refactoring, 2nd ed.). Diagnoses code smells, applies refactorings step-by-step with tests between steps, and teaches when and why to use each technique — language-agnostic. Includes an installable GitHub Actions PR-review workflow",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Jeb Coleman"
       }

--- a/plugins/fowler/.claude-plugin/plugin.json
+++ b/plugins/fowler/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fowler",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Refactoring advisor grounded in Martin Fowler's catalog (Refactoring, 2nd ed.). Diagnoses code smells, applies refactorings step-by-step with tests between steps, and teaches when and why to use each technique — language-agnostic",
   "author": {
     "name": "Jeb Coleman"

--- a/plugins/fowler/templates/fowler-review.yml
+++ b/plugins/fowler/templates/fowler-review.yml
@@ -12,6 +12,12 @@ on:
   issue_comment:
     types: [created]
 
+# One run per PR at a time: a newer trigger (another /fowler comment, or a rapid
+# reopen) cancels the in-flight run instead of posting duplicate comments.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write
@@ -103,7 +109,10 @@ jobs:
           # The allowlist must cover everything the prompt instructs: `Skill`
           # to invoke /fowler:fowler (denied tools fail silently in CI), and
           # git/gh diff commands so the review can actually see the PR's diff.
+          # No generic filesystem Bash (cat/head/find/...): Read/Grep/Glob
+          # already cover file inspection, and cat + gh pr comment would let a
+          # prompt-injected diff exfiltrate secrets from the runner environment.
           claude_args: |
             --model claude-sonnet-5
-            --allowedTools "Skill,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git status:*),Bash(git branch:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Read,Grep,Glob"
+            --allowedTools "Skill,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git status:*),Bash(git branch:*),Read,Grep,Glob"
             --max-turns 100

--- a/plugins/sandi/.claude-plugin/plugin.json
+++ b/plugins/sandi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sandi",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Object-oriented design advisor channeling Sandi Metz's philosophy (POODR, 99 Bottles of OOP). Plans, reviews, audits whole codebases, refactors, and teaches OO design — language-agnostic",
   "author": {
     "name": "Jeb Coleman"

--- a/plugins/sandi/templates/sandi-review.yml
+++ b/plugins/sandi/templates/sandi-review.yml
@@ -12,6 +12,12 @@ on:
   issue_comment:
     types: [created]
 
+# One run per PR at a time: a newer trigger (another /sandi comment, or a rapid
+# reopen) cancels the in-flight run instead of posting duplicate comments.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write
@@ -99,7 +105,10 @@ jobs:
           # The allowlist must cover everything the prompt instructs: `Skill`
           # to invoke /sandi:sandi (denied tools fail silently in CI), and
           # git/gh diff commands so the review can actually see the PR's diff.
+          # No generic filesystem Bash (cat/head/find/...): Read/Grep/Glob
+          # already cover file inspection, and cat + gh pr comment would let a
+          # prompt-injected diff exfiltrate secrets from the runner environment.
           claude_args: |
             --model claude-sonnet-5
-            --allowedTools "Skill,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git status:*),Bash(git branch:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Read,Grep,Glob"
+            --allowedTools "Skill,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git fetch:*),Bash(git status:*),Bash(git branch:*),Read,Grep,Glob"
             --max-turns 100


### PR DESCRIPTION
## Summary

Addresses two review findings on the installable `fowler-review.yml` / `sandi-review.yml` GitHub Actions templates:

- **Narrow `--allowedTools`**: removed the generic filesystem Bash commands (`ls`, `cat`, `head`, `tail`, `wc`, `find`). `Read`/`Grep`/`Glob` already cover file inspection, and `cat` combined with the already-allowed `gh pr comment` would let a prompt-injected fork-PR diff read runner secrets (e.g. `/proc/self/environ`) and post them to the PR. The commenter-trust gate doesn't mitigate this because the injection lives in the reviewed content, not the trigger. A comment above the allowlist documents the exclusion so the commands don't get re-added.
- **Per-PR concurrency**: added a `concurrency` group keyed on `github.workflow` + PR number (with `issue.number` fallback for comment triggers) and `cancel-in-progress: true`, so repeated `/fowler` / `/sandi` comments or rapid open/reopen cycles cancel the in-flight run instead of spamming duplicate inline comments.

Version bumps so the fixes flow through the marketplace: fowler 0.2.0 → 0.2.1, sandi 0.3.0 → 0.3.1, marketplace metadata 1.0.8 → 1.0.9.

## Notes

- Repos that already ran `/fowler:install-review` or `/sandi:install-review` have the old workflow baked in and need to re-run the installer (or hand-edit) to pick this up.
- Not airtight: `Read` can technically still reach `/proc`; this narrows the realistic surface without changing the auth architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)