### PR TITLE
feat(ruby-rails): add application-template coverage to rails-generators skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "ruby-rails",
       "source": "./plugins/ruby-rails",
       "description": "Ruby on Rails development toolkit with skills for Rails, Ruby, RSpec, RuboCop, SimpleCov, Brakeman, TestProf performance diagnosis, and code review with Sandi Metz principles",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "Jeb Coleman"
       }

--- a/plugins/ruby-rails/.claude-plugin/plugin.json
+++ b/plugins/ruby-rails/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ruby-rails",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Ruby on Rails development toolkit with skills for Rails, Ruby, RSpec, RuboCop, SimpleCov, Brakeman, TestProf performance diagnosis, and code review with Sandi Metz principles",
   "author": {
     "name": "Jeb Coleman"

--- a/plugins/ruby-rails/skills/rails-generators/SKILL.md
+++ b/plugins/ruby-rails/skills/rails-generators/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: rails-generators
-description: Create expert-level Ruby on Rails generators for models, services, controllers, and full-stack features. Use when building custom generators, scaffolds, or code generation tools for Rails applications, or when the user mentions Rails generators, Thor DSL, or automated code generation.
+description: Create expert-level Ruby on Rails generators for models, services, controllers, and full-stack features, plus application templates for whole-app setup. Use when building custom generators, scaffolds, code generation tools, or Rails application templates (rails new -m, app:template, starter-app automation, multi-tenant setup), or when the user mentions Rails generators, Thor DSL, or automated code generation.
 ---
 
 <objective>
-Build production-ready Rails generators that automate repetitive coding tasks and enforce architectural patterns. This skill covers creating custom generators for models, service objects, API scaffolds, and complete features with migrations, tests, and documentation.
+Build production-ready Rails generators that automate repetitive coding tasks and enforce architectural patterns. This skill covers creating custom generators for models, service objects, API scaffolds, and complete features with migrations, tests, and documentation — plus application templates (`rails new -m` / `app:template`) for whole-app setup such as authentication and multi-tenancy.
 </objective>
 
 <quick_start>
@@ -333,6 +333,39 @@ See [references/file-actions.md](references/file-actions.md) for complete refere
 </file_manipulation>
 </advanced_features>
 
+<application_templates>
+**Application templates** configure a whole app (gems, auth, config, feature sets) rather than generating one component. They use the same Thor action DSL but are invoked with `rails new myapp -m template.rb` or `bin/rails app:template LOCATION=template.rb`:
+
+```ruby
+# multitenant_template.rb
+def source_paths
+  [__dir__]
+end
+
+# Guard against double application
+if File.exist?('app/models/organization.rb')
+  say '❌ Template already applied.', :red
+  exit 1
+end
+
+gem 'devise', comment: 'Authentication'
+gem 'acts_as_tenant', comment: 'Row-level multi-tenancy'
+run 'bundle install'
+
+# Always use the gems' own install generators — never hand-write their config
+generate 'devise:install'
+generate 'devise', 'User'
+
+rails_command 'db:migrate'
+run 'bundle exec rspec'  # fail loudly at apply time, not first boot
+```
+
+**Key rules**: guard against re-runs (injections corrupt on second apply), prefer gem install generators over hand-rolled setup, prefer `inject_into_file` on stable anchors over brittle `gsub_file` regexes, and end by running the app's test suite.
+
+- See [references/application-templates.md](references/application-templates.md) for the full DSL, `after_bundle`, composing templates with `apply`, and verification workflow
+- See [references/multitenant-template.md](references/multitenant-template.md) for a complete worked example: multi-tenant SaaS setup with acts_as_tenant, Organizations, role-based Memberships, and invitations
+</application_templates>
+
 <testing>
 **Testing with Rails::Generators::TestCase**:
 
@@ -407,6 +440,8 @@ Before considering a generator complete, verify:
 - [Rails testing](references/testing-rails.md) - Rails::Generators::TestCase patterns
 - [RSpec testing](references/testing-rspec.md) - generator_spec and RSpec patterns
 - [Examples](references/examples.md) - Complete generator examples (query objects, form objects, presenters)
+- [Application templates](references/application-templates.md) - Whole-app setup via `rails new -m` / `app:template`
+- [Multi-tenant template](references/multitenant-template.md) - Worked example: acts_as_tenant, Organizations, Memberships, invitations
 </reference_guides>
 
 <success_criteria>

--- a/plugins/ruby-rails/skills/rails-generators/references/application-templates.md
+++ b/plugins/ruby-rails/skills/rails-generators/references/application-templates.md
@@ -1,0 +1,241 @@
+# Rails Application Template Patterns
+
+Application templates are Ruby scripts that configure a whole Rails application — adding gems, running installers, creating files, and modifying configuration. They use the same Thor action DSL as custom generators but run against the entire app rather than generating a single component.
+
+## Table of Contents
+
+- [Templates vs Generators](#templates-vs-generators)
+- [Invocation](#invocation)
+- [Template Structure](#template-structure)
+- [The Application Template DSL](#the-application-template-dsl)
+- [Prefer Gem Installers Over Hand-Rolled Setup](#prefer-gem-installers-over-hand-rolled-setup)
+- [Idempotency Guards](#idempotency-guards)
+- [Interactive Prompts](#interactive-prompts)
+- [Composing Templates](#composing-templates)
+- [Common Gotchas](#common-gotchas)
+- [Verifying the Template](#verifying-the-template)
+
+## Templates vs Generators
+
+| | Custom generator | Application template |
+|---|---|---|
+| Invoked with | `rails generate foo` | `rails new app -m template.rb` or `bin/rails app:template` |
+| Scope | One component (model, service, controller) | Whole-app setup (gems, auth, config, features) |
+| Lives in | `lib/generators/` inside an app or gem | Standalone `.rb` file (local path or URL) |
+| Base class | `Rails::Generators::Base` / `NamedBase` | None — top-level script evaluated in a `Rails::Generators::AppGenerator` context |
+| Repeatable | Yes, designed for repeated use | Usually once per app; guard against re-runs |
+
+Use a generator when the team will invoke it repeatedly inside one app. Use an application template when standing up new apps from a starter (or retrofitting a feature set like authentication or multi-tenancy onto an existing app).
+
+## Invocation
+
+```bash
+# Apply while creating a new app
+rails new myapp -m path/to/template.rb
+
+# Apply to an existing app
+bin/rails app:template LOCATION=path/to/template.rb
+
+# Templates can also be loaded from a URL
+rails new myapp -m https://example.com/template.rb
+```
+
+## Template Structure
+
+A well-structured template follows this order:
+
+```ruby
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# 1. Make relative paths (partials, copied files) resolve next to the template
+def source_paths
+  [__dir__]
+end
+
+# 2. Guard against double application (see Idempotency Guards)
+if File.exist?('app/models/organization.rb')
+  say "Template already applied. Exiting.", :red
+  exit 1
+end
+
+# 3. Add gems, then install
+gem 'devise', comment: 'Authentication (https://github.com/heartcombo/devise)'
+gem_group :development do
+  gem 'letter_opener', comment: 'Preview email in the browser'
+end
+run 'bundle install'
+
+# 4. Run the gems' own install generators
+generate 'devise:install'
+generate 'devise', 'User'
+
+# 5. Create/modify application files
+create_file 'app/models/organization.rb', <<~RUBY
+  class Organization < ApplicationRecord
+    validates :name, presence: true, uniqueness: true
+  end
+RUBY
+
+# 6. Migrate and verify
+rails_command 'db:migrate'
+run 'bundle exec rspec'
+
+say "✅ Setup complete!", :green
+```
+
+Progress output with `say` (optionally colored: `:green`, `:yellow`, `:red`) keeps long-running templates legible.
+
+## The Application Template DSL
+
+All Thor actions from generators are available (`create_file`, `template`, `inject_into_file`, `gsub_file`, `insert_into_file`, `route`, `initializer` — see [file-actions.md](file-actions.md)), plus app-template-specific methods:
+
+```ruby
+# Gemfile management
+gem 'sidekiq'
+gem 'rspec-rails', group: [:development, :test]
+gem_group :development, :test do
+  gem 'factory_bot_rails'
+end
+add_source 'https://gems.example.com'
+
+# Environment configuration
+environment 'config.active_job.queue_adapter = :sidekiq'
+environment 'config.action_mailer.delivery_method = :letter_opener', env: 'development'
+
+# Run generators and commands
+generate 'devise:install'
+generate 'model', 'Organization', 'name:string', 'description:text'
+rails_command 'db:migrate'
+rails_command 'db:seed', abort_on_failure: true
+rake 'assets:precompile', env: 'production'
+run 'bundle exec rubocop -a'
+
+# Files under lib/ and vendor/
+lib 'tenant_utils.rb', <<~RUBY
+  module TenantUtils
+  end
+RUBY
+vendor 'styles.css', '.tenant-badge { color: red; }'
+
+# Git operations
+git :init
+git add: '.', commit: %(-m 'Apply multi-tenant template')
+
+# Defer work until after bundle install completes (rails new only)
+after_bundle do
+  rails_command 'db:migrate'
+  git add: '.', commit: %(-m 'Initial commit')
+end
+```
+
+When run via `rails new -m`, gems added at the top are installed by the initial `bundle install`; use `after_bundle` for steps that need the bundle. When run via `app:template` against an existing app, call `run 'bundle install'` explicitly after adding gems and before invoking their generators.
+
+## Prefer Gem Installers Over Hand-Rolled Setup
+
+Always use the install generators provided by the gems rather than hand-writing their configuration:
+
+```ruby
+generate 'devise:install'        # not: create_file 'config/initializers/devise.rb', ...
+generate 'devise', 'User'
+generate 'devise:views'
+generate 'action_policy:install'
+generate 'flipper:setup'
+```
+
+Gem installers track the gem's current version; hand-written config drifts and encodes assumptions from whenever the template was written. Reserve `create_file`/`inject_into_file` for your application code and for post-install customization of what the installer produced.
+
+## Idempotency Guards
+
+Application templates modify files with `inject_into_file` and `gsub_file`, so a second run corrupts the app (duplicate injections, double routes). Guard at the top:
+
+```ruby
+def template_already_applied?
+  return true if File.exist?('app/models/organization.rb')
+
+  routes_content = File.read('config/routes.rb') rescue ""
+  return true if routes_content.include?('devise_for :users')
+
+  begin
+    ActiveRecord::Base.connection.execute('SELECT 1 FROM organizations LIMIT 1')
+    return true
+  rescue ActiveRecord::StatementInvalid, ActiveRecord::NoDatabaseError
+    # table doesn't exist — safe to proceed
+  end
+
+  false
+end
+
+if template_already_applied?
+  say '❌ Template already applied. Restore from git to reapply.', :red
+  exit 1
+end
+```
+
+Check several signals (key files, route contents, database tables) — a partial prior run may have created some but not others.
+
+## Interactive Prompts
+
+```ruby
+app_name = ask('What is the product name?')
+use_api = yes?('Generate API endpoints? (y/n)')
+
+gem 'jbuilder' if use_api
+```
+
+Prompts make a template flexible but break unattended use (CI, scripted app creation). Prefer detecting from the environment or reading an ENV variable, and fall back to a prompt:
+
+```ruby
+use_api = ENV.fetch('TEMPLATE_API', nil) == 'true' || yes?('Generate API endpoints? (y/n)')
+```
+
+## Composing Templates
+
+Split large setups into focused templates and compose them with `apply`:
+
+```ruby
+# main_template.rb
+def source_paths
+  [__dir__]
+end
+
+apply 'authentication_template.rb'
+apply 'multitenant_template.rb'
+apply 'admin_template.rb'
+```
+
+Each sub-template stays independently applicable (with its own guard), which makes them testable in isolation and lets existing apps adopt one feature set at a time.
+
+## Common Gotchas
+
+**Migration timestamp collisions**: creating migrations with `create_file "db/migrate/#{Time.now.strftime('%Y%m%d%H%M%S')}_..."` in a loop produces duplicate timestamps. Prefer `generate 'migration', 'CreateOrganizations', 'name:string'` or the gem's generators, which handle sequencing. If you must hand-create several, sleep between them — but treat that as a smell.
+
+**Escaping interpolation in heredocs**: Ruby code written inside a template's heredoc that itself contains `#{}` must be escaped (`\#{user.name}`) or the template evaluates it at apply time. Use `<<~'RUBY'` (single-quoted heredoc) when the generated code needs literal interpolation and the template needs none.
+
+**`gsub_file` with brittle regexes**: matching multi-line method bodies with `/def index.*?end/m` breaks silently when the target app's code differs from what the template expects. Prefer `inject_into_file` anchored on stable lines (class definitions, `Rails.application.routes.draw do`), and verify with tests after applying.
+
+**Devise and mailer hosts**: templates that add Devise must also set `config.action_mailer.default_url_options` in development or the first sign-up email raises.
+
+## Verifying the Template
+
+A template is code — test it by applying it:
+
+```bash
+# Fresh-app path
+rails new /tmp/template_check -m path/to/template.rb
+
+# Existing-app path (from a clean git state)
+cd existing-app
+git status --porcelain   # must be empty first
+bin/rails app:template LOCATION=path/to/template.rb
+git diff                 # review every change the template made
+bundle exec rspec
+git checkout . && git clean -fd   # reset for the next iteration
+```
+
+End the template itself with the app's test suite (`run 'bundle exec rspec'`) so a broken application fails loudly at apply time, not at first boot. See [multitenant-template.md](multitenant-template.md) for a complete worked example.
+
+## Sources
+
+- [Rails Application Templates — Ruby on Rails Guides](https://guides.rubyonrails.org/rails_application_templates.html)
+- [Creating and Customizing Rails Generators & Templates — Ruby on Rails Guides](https://guides.rubyonrails.org/generators.html)

--- a/plugins/ruby-rails/skills/rails-generators/references/multitenant-template.md
+++ b/plugins/ruby-rails/skills/rails-generators/references/multitenant-template.md
@@ -1,0 +1,396 @@
+# Multi-Tenant Application Template (Worked Example)
+
+A complete application template that turns a Rails starter app into a SaaS-ready multi-tenant platform: Organizations as tenants, role-based Memberships, email invitations, and automatic data isolation via [acts_as_tenant](https://github.com/ErwinM/acts_as_tenant).
+
+**Tenancy approach**: use the `acts_as_tenant` gem, not hand-rolled `organization_id` scoping. The gem gives default-scope isolation (an unscoped query cannot leak another tenant's rows), automatic assignment on create, and uniqueness validation scoped to the tenant — guarantees a controller concern can't match.
+
+## Table of Contents
+
+- [Architecture](#architecture)
+- [Template Skeleton](#template-skeleton)
+- [Tenant Model: Organization](#tenant-model-organization)
+- [Membership: Roles and Invitations](#membership-roles-and-invitations)
+- [Tenant Selection from the URL](#tenant-selection-from-the-url)
+- [Scoping Models](#scoping-models)
+- [Registration Flow](#registration-flow)
+- [Background Jobs](#background-jobs)
+- [Testing](#testing)
+
+## Architecture
+
+```text
+User ──< Membership >── Organization (the tenant)
+              │
+              └── role: admin | member | viewer
+                  + invitation fields (token, email, expiry)
+
+Tenant-scoped models:  acts_as_tenant(:organization)
+Tenant selection:      URL (/organizations/:organization_slug/...) via set_current_tenant_through_filter
+```
+
+- **Organization** is the tenant model (not the gem's default `Account` — after running any gem installer, rename generated `Account` references to `Organization`).
+- **Membership** joins Users to Organizations and carries the role; authorization (e.g. Action Policy) reads roles from it.
+- Every tenant-owned model declares `acts_as_tenant(:organization)`; queries are then scoped automatically.
+
+## Template Skeleton
+
+```ruby
+# multitenant_template.rb — apply with:
+#   rails new myapp -m multitenant_template.rb
+#   bin/rails app:template LOCATION=multitenant_template.rb
+
+def source_paths
+  [__dir__]
+end
+
+# Idempotency guard — see application-templates.md
+if File.exist?('app/models/organization.rb')
+  say '❌ Multi-tenant template already applied.', :red
+  exit 1
+end
+
+say '📦 Adding gems...'
+gem 'devise', comment: 'Authentication (https://github.com/heartcombo/devise)'
+gem 'acts_as_tenant', comment: 'Row-level multi-tenancy (https://github.com/ErwinM/acts_as_tenant)'
+gem_group :development do
+  gem 'letter_opener', comment: 'Preview email in the browser'
+end
+run 'bundle install'
+
+say '🔐 Installing Devise via its own generators...'
+generate 'devise:install'
+generate 'devise', 'User'
+generate 'devise:views'
+environment "config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }",
+            env: 'development'
+
+say '🏢 Creating tenant models...'
+generate 'model', 'Organization', 'name:string:uniq', 'slug:string:uniq', 'description:text'
+generate 'model', 'Membership',
+         'organization:references', 'user:references',
+         'role:string', 'invited_by:references',
+         'invitation_token:string:uniq', 'invited_email:string',
+         'invitation_expires_at:datetime'
+
+# ... model bodies, controller filter, routes (sections below) ...
+
+rails_command 'db:migrate'
+run 'bundle exec rspec'
+say '✅ Multi-tenant setup complete!', :green
+```
+
+Note the template runs each gem's own install generator (`devise:install`, `generate 'devise', 'User'`) instead of hand-writing initializers — see [application-templates.md](application-templates.md#prefer-gem-installers-over-hand-rolled-setup).
+
+## Tenant Model: Organization
+
+```ruby
+create_file 'app/models/organization.rb', <<~RUBY, force: true
+  class Organization < ApplicationRecord
+    acts_as_tenant
+
+    validates :name, presence: true, uniqueness: true
+    validates :slug, presence: true, uniqueness: true
+
+    has_many :memberships, dependent: :destroy
+    has_many :users, through: :memberships
+
+    scope :ordered, -> { order(:name) }
+
+    def to_param = slug
+  end
+RUBY
+```
+
+## Membership: Roles and Invitations
+
+Membership carries both the role (feeding role-based authorization) and the invitation lifecycle. Membership is deliberately **not** tenant-scoped with `acts_as_tenant` — it is the join that defines who belongs to a tenant, and it must be queryable across tenants (e.g. finding an invitation by token before the user has a tenant).
+
+```ruby
+create_file 'app/models/membership.rb', force: true do
+  <<~'RUBY'
+    class Membership < ApplicationRecord
+      ROLES = %w[admin member viewer].freeze
+
+      belongs_to :organization
+      belongs_to :user, optional: true
+      belongs_to :invited_by, class_name: 'User', optional: true
+
+      validates :role, presence: true, inclusion: { in: ROLES }
+      validates :user_id, uniqueness: { scope: :organization_id }, if: :user_id?
+      validates :invited_email, presence: true,
+                uniqueness: { scope: :organization_id }, if: :pending_invitation?
+
+      scope :active,  -> { where.not(user_id: nil) }
+      scope :pending, -> { where(user_id: nil) }
+
+      before_validation :generate_invitation_token, if: :pending_invitation?
+      before_validation :set_invitation_expiry, if: :pending_invitation?
+
+      def pending_invitation? = user_id.nil? && invited_email.present?
+      def admin?  = role == 'admin'
+      def member? = role == 'member'
+      def viewer? = role == 'viewer'
+
+      def invitation_expired?
+        pending_invitation? && invitation_expires_at&.past?
+      end
+
+      def accept_invitation!(user)
+        return false unless pending_invitation? && !invitation_expired?
+
+        update!(user: user, invitation_token: nil,
+                invited_email: nil, invitation_expires_at: nil)
+      end
+
+      private
+
+      def generate_invitation_token
+        self.invitation_token = SecureRandom.urlsafe_base64(32)
+      end
+
+      def set_invitation_expiry
+        self.invitation_expires_at ||= 7.days.from_now
+      end
+    end
+  RUBY
+end
+```
+
+Key migration indexes (add to the generated migration):
+
+```ruby
+add_index :memberships, [:organization_id, :user_id],
+          unique: true, where: 'user_id IS NOT NULL'
+add_index :memberships, [:organization_id, :invited_email],
+          unique: true, where: 'user_id IS NULL'
+```
+
+The partial indexes allow the same email to hold pending invitations in different organizations while preventing duplicates within one.
+
+Convenience methods on User:
+
+```ruby
+inject_into_file 'app/models/user.rb', after: "class User < ApplicationRecord\n" do
+  <<-RUBY
+  has_many :memberships, dependent: :destroy
+  has_many :organizations, through: :memberships
+  has_many :sent_invitations, class_name: 'Membership', foreign_key: 'invited_by_id'
+
+  def admin_of?(organization)
+    memberships.find_by(organization: organization)&.admin?
+  end
+
+  def member_of?(organization)
+    memberships.exists?(organization: organization)
+  end
+  RUBY
+end
+```
+
+> **Alternative**: [devise_invitable](https://github.com/scambra/devise_invitable) manages invitations at the User level via its own generator (`generate 'devise_invitable:install'`, `generate 'devise_invitable', 'User'`). Use it when invitations should create user accounts directly; keep the Membership-token approach above when an existing user can be invited into additional organizations.
+
+## Tenant Selection from the URL
+
+The tenant comes from the URL, so links are shareable and a user can be active in different organizations in different tabs.
+
+```ruby
+inject_into_file 'app/controllers/application_controller.rb',
+                 after: "class ApplicationController < ActionController::Base\n" do
+  <<-RUBY
+  set_current_tenant_through_filter
+  before_action :set_current_organization
+
+  private
+
+  def set_current_organization
+    slug = params[:organization_slug] || params[:organization_id]
+    organization = slug && current_user&.organizations&.find_by(slug: slug)
+
+    if slug && organization.nil?
+      raise ActiveRecord::RecordNotFound  # member-only access; renders 404
+    end
+
+    set_current_tenant(organization)
+  end
+
+  def current_organization = ActsAsTenant.current_tenant
+  helper_method :current_organization
+  RUBY
+end
+```
+
+Looking the organization up through `current_user.organizations` (not `Organization.find_by`) makes membership itself the access check — non-members get a 404, not a 403 that confirms the organization exists.
+
+Routes nest tenant-owned resources under the organization:
+
+```ruby
+route <<~RUBY
+  devise_for :users, controllers: { registrations: 'users/registrations' }
+
+  get 'invitations/:token/accept', to: 'memberships#accept', as: :accept_invitation
+
+  resources :organizations, param: :slug do
+    resources :memberships, except: %i[show new edit]
+    resources :projects   # tenant-scoped resources nest here
+  end
+
+  authenticated :user do
+    root to: 'organizations#index', as: :authenticated_root
+  end
+RUBY
+```
+
+## Scoping Models
+
+Every tenant-owned model declares the scope; controllers then use plain ActiveRecord:
+
+```ruby
+class Project < ApplicationRecord
+  acts_as_tenant(:organization)
+
+  # Tenant-scoped uniqueness — plain `uniqueness: true` would collide across tenants
+  validates :name, uniqueness: { scope: :organization_id }
+end
+```
+
+```ruby
+class ProjectsController < ApplicationController
+  def index
+    @projects = Project.all      # scoped to current tenant automatically
+  end
+
+  def create
+    @project = Project.new(project_params)  # organization_id assigned automatically
+    ...
+  end
+end
+```
+
+The template can offer this as a follow-up generator for new resources, or teams add the one line by hand. Migrations for tenant-scoped tables should make the foreign key mandatory:
+
+```ruby
+add_reference :projects, :organization, null: false, foreign_key: true
+```
+
+Use `null: true` only for tables that intentionally hold public/untenanted rows — and know that `acts_as_tenant` still hides those rows whenever a tenant is set.
+
+## Registration Flow
+
+New sign-ups either accept a pending invitation (token stashed in the session) or get a personal organization created for them:
+
+```ruby
+create_file 'app/controllers/users/registrations_controller.rb', <<~'RUBY'
+  class Users::RegistrationsController < Devise::RegistrationsController
+    protected
+
+    def after_sign_up_path_for(user)
+      membership = Membership.find_by(invitation_token: session.delete(:invitation_token))
+
+      if membership&.accept_invitation!(user)
+        organization_path(membership.organization)
+      else
+        organization = ActsAsTenant.without_tenant do
+          Organization.create!(name: "#{user.email}'s Organization",
+                               slug: SecureRandom.hex(4)).tap do |org|
+            org.memberships.create!(user: user, role: 'admin')
+          end
+        end
+        organization_path(organization)
+      end
+    end
+  end
+RUBY
+```
+
+The invitation-acceptance endpoint (`memberships#accept`) finds the membership by token, accepts directly for signed-in users, and stores the token in the session before redirecting guests to sign-up. Send invitation emails from a mailer with `deliver_later`, and add `letter_opener` in development to preview them.
+
+## Background Jobs
+
+`ActsAsTenant.current_tenant` is per-request; jobs must set it explicitly:
+
+```ruby
+class SyncProjectsJob < ApplicationJob
+  def perform(organization)
+    ActsAsTenant.with_tenant(organization) do
+      Project.find_each(&:sync!)   # scoped to organization
+    end
+  end
+end
+```
+
+Pass the organization (or its id) as a job argument — never rely on ambient tenant state surviving into the job. For maintenance scripts that legitimately cross tenants, use `ActsAsTenant.without_tenant { ... }`.
+
+## Testing
+
+Factories:
+
+```ruby
+FactoryBot.define do
+  factory :organization do
+    sequence(:name) { |n| "Organization #{n}" }
+    sequence(:slug) { |n| "org-#{n}" }
+  end
+
+  factory :membership do
+    organization
+    user
+    role { 'member' }
+
+    trait :admin   { role { 'admin' } }
+    trait :pending do
+      user { nil }
+      sequence(:invited_email) { |n| "invited#{n}@example.com" }
+    end
+    trait :expired do
+      pending
+      invitation_expires_at { 1.hour.ago }
+    end
+  end
+end
+```
+
+Set a test tenant globally so model specs don't fail tenant-presence validations, and override per-example when testing isolation:
+
+```ruby
+# spec/rails_helper.rb
+RSpec.configure do |config|
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
+  config.before(:suite) { ActsAsTenant.test_tenant = FactoryBot.create(:organization) }
+  config.after(:suite)  { ActsAsTenant.test_tenant = nil }
+end
+```
+
+The test that matters most — isolation actually holds:
+
+```ruby
+RSpec.describe 'tenant isolation', type: :request do
+  let(:org_a) { create(:organization) }
+  let(:org_b) { create(:organization) }
+  let(:user)  { create(:user) }
+
+  before { create(:membership, user: user, organization: org_a) }
+
+  it 'hides other tenants\' records' do
+    project_b = ActsAsTenant.with_tenant(org_b) { create(:project) }
+
+    sign_in user
+    get organization_projects_path(org_a)
+    expect(response.body).not_to include(project_b.name)
+  end
+
+  it 'returns 404 for organizations the user does not belong to' do
+    sign_in user
+    get organization_projects_path(org_b)
+    expect(response).to have_http_status(:not_found)
+  end
+end
+```
+
+Finish the template by running migrations and the full suite (`rails_command 'db:migrate'`, `run 'bundle exec rspec'`) so a broken apply fails immediately.
+
+## Sources
+
+- [acts_as_tenant README](https://github.com/ErwinM/acts_as_tenant)
+- [Rails Application Templates — Ruby on Rails Guides](https://guides.rubyonrails.org/rails_application_templates.html)
+- [Devise](https://github.com/heartcombo/devise) / [devise_invitable](https://github.com/scambra/devise_invitable)


### PR DESCRIPTION
## Summary

Folds the multi-tenant starter-app template work (from `super-templatus`) into the `rails-generators` skill, which previously had no coverage of Rails application templates (`rails new -m` / `bin/rails app:template`).

- **`references/application-templates.md`** — generic mechanism: templates vs. generators, invocation paths, the app-template-only DSL (`gem`/`gem_group`, `environment`, `after_bundle`, `apply`), idempotency guards, the "use the gems' own install generators" rule, common gotchas (migration timestamp collisions, heredoc interpolation escaping, brittle `gsub_file` regexes), and a verification workflow.
- **`references/multitenant-template.md`** — complete worked example canonicalized on `acts_as_tenant`: Organization as tenant, role-based Membership join with token-based invitations (partial unique indexes), URL-based tenant selection via `set_current_tenant_through_filter`, registration flow (accept invite or create personal org), background-job tenant context, factories and isolation specs. Notes `devise_invitable` as the user-level alternative.
- **`SKILL.md`** — new `<application_templates>` section with a compact skeleton linking both references; frontmatter description and objective updated so the skill triggers on application-template and multi-tenant setup requests.

Deliberately excluded: the runnable Templatus-specific scripts (app-specific, stay in super-templatus) and the starter-app playbook items from plan.md (layouts, analytics, feature flags, admin UI) that aren't generator knowledge.

## Test plan

- [ ] `SKILL.md` reference links resolve to the two new files
- [ ] New section follows the existing SKILL.md snippet → reference-file pattern
- [ ] Multi-tenant reference consistently uses acts_as_tenant (no hand-rolled scoping as primary path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)